### PR TITLE
Capitalize license edition

### DIFF
--- a/web/craftidresources/src/js/components/CmsLicenseDetails.vue
+++ b/web/craftidresources/src/js/components/CmsLicenseDetails.vue
@@ -8,7 +8,7 @@
 						<div class="md:w-1/2 px-4">
 							<dl>
 								<dt>Edition</dt>
-								<dd>{{ license.edition }}</dd>
+								<dd>{{ license.edition|capitalize }}</dd>
 
 								<dt>License Key</dt>
 								<dd><code>{{ license.key.slice(0, 10) }}…</code> <a href="#license-key">View license key</a></dd>

--- a/web/craftidresources/src/js/components/CmsLicensesTable.vue
+++ b/web/craftidresources/src/js/components/CmsLicensesTable.vue
@@ -29,7 +29,7 @@
 						</code>
 					</td>
 
-					<td>{{ license.edition }}</td>
+					<td>{{ license.edition|capitalize }}</td>
 					<td>{{ license.domain }}</td>
 					<td>{{ license.notes }}</td>
 


### PR DESCRIPTION
The edition name is a proper noun, so it should at least be capitalized. ("Solo" & "Pro")