### PR TITLE
Added madebyshape-dev.co.uk and madebyshape.dev

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -40,6 +40,8 @@ return [
     'hyperlane.co',
     'infomedia-dev.com',
     'madebymasuga.com',
+    'madebyshape-dev.co.uk',
+    'madebyshape.dev',
     'mandarindev.no',
     'manual.casa',
     'mcipreview.com',


### PR DESCRIPTION
These are domains we use for development, allowing clients to work privately on their sites.