### PR TITLE
Update No-Cache handle in craft2-plugins.php

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -326,6 +326,9 @@ return [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Navigation](https://github.com/verbb/navigation) can be used instead.'
     ],
+    'NoCache' => [
+        'handle' => 'nocache',
+    ],
     'NpEditMultipleElements' => [
         'handle' => 'sequential-edit',
     ],


### PR DESCRIPTION
Adds No-Cache to the Craft 2 plugin availability list, as the Craft 3 version's handle does not follow kebab-case.

- No-Cache: https://github.com/ttempleton/craft-nocache
- Craft 2 version: https://github.com/ttempleton/craft-nocache/tree/craft-2