### PR TITLE
Add Craft 3 alternative for Gulp Rev plugin

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -223,6 +223,10 @@ return [
         'statusColor' => 'orange',
         'status' => 'Discontinued, but [Smart Map](https://www.doublesecretagency.com/plugins/smart-map) can be used instead.'
     ],
+    'GulpRev' => [
+        'statusColor' => 'orange',
+        'status' => 'Not available yet, but [Craft Asset Rev](https://github.com/clubstudioltd/craft-asset-rev) can be used instead.'
+    ],
     'Hacksaw' => [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Wordsmith](https://wordsmith.docs.topshelfcraft.com/guide/truncation.html#hacksaw) or [Typogrify](https://github.com/nystudio107/craft3-typogrify) can be used instead.'


### PR DESCRIPTION
Gulp Rev: https://github.com/vigetlabs/blendid/tree/master/extras/craft/craft/plugins/gulprev.

It doesn't look likely that Gulp Rev will be updated for Craft 3 support, however [Craft Asset Rev](https://github.com/clubstudioltd/craft-asset-rev) seems to be suitable alternative that will provide the same functionality and has more features.