### PR TITLE
Add note for FeedMeHelper plugin

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -182,7 +182,7 @@ return [
     ],
     'FeedMeHelper' => [
         'statusColor' => 'orange',
-        'status' => 'No longer needed thanks to native support for CSV being implemented in the main [Feed Me plugin](https://github.com/verbb/feed-me).'
+        'status' => 'No longer needed now that the [Feed Me](https://github.com/verbb/feed-me) plugin natively supports CSV.'
     ],
     'FieldGuide' => [
         'statusColor' => 'orange',

--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -180,6 +180,10 @@ return [
         'statusColor' => 'orange',
         'status' => 'Discontinued, but [Beam](https://github.com/sjelfull/craft3-beam) or [Export CSV](https://github.com/kffein/Craft-export-Csv) can be used instead,'
     ],
+    'FeedMeHelper' => [
+        'statusColor' => 'orange',
+        'status' => 'No longer needed thanks to native support for CSV being implemented in the main [Feed Me plugin](https://github.com/verbb/feed-me).'
+    ],
     'FieldGuide' => [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Field Manager](https://github.com/verbb/field-manager) can be used instead.'


### PR DESCRIPTION
In Craft 2 there was a Feed Me helper plugin which provided the ability to import data as CSV as extended functionality on top of the existing plugin. 

Under Craft 3, this no longer required because Feed Me itself supports the CSV format natively.