### PR TITLE
Redirect Relabel Craft 2 plugin to Field Labels

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -402,6 +402,9 @@ return [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Retour](https://github.com/nystudio107/craft-retour) can be used instead.'
     ],
+    'Relabel' => [
+        'handle' => 'fieldlabels',
+    ],
     'Reports' => [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Sprout Reports](https://github.com/barrelstrength/craft-sprout-reports) can be used instead.'


### PR DESCRIPTION
The original Relabel plugin for Craft 2 has been renamed to Field Labels for Craft 3, due to another plugin having taken the Relabel name on the Plugin Store.

See:
- Field Labels: https://github.com/spicywebau/craft-fieldlabels
- Relabel for Craft 2: https://github.com/spicywebau/craft-fieldlabels/tree/craft-2
- The plugin that has taken the Relabel name for Craft 3: https://github.com/Anubarak/craft-relabel
