### PR TITLE
Add specific note for Craft 2 CloudFront invalidation plugin

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -105,6 +105,10 @@ return [
     'Charge' => [
         'status' => 'Currently in development.'
     ],
+    'CloudfrontInvalidation' => [
+        'statusColor' => 'orange',
+        'status' => 'No longer needed thanks to automatic CloudFront invalidation functionality in the [AWS S3](https://github.com/craftcms/aws-s3) plugin.'
+    ],
     'CodeBlock' => [
         'statusColor' => 'orange',
         'status' => 'Discontinued, but [Simple Text](https://github.com/craftcms/simple-text) can be used instead.'


### PR DESCRIPTION
Adds a specific note for the Craft 2 Cloudfront Invalidation plugin. It's functionality is now performed by the AWS S3 plugin in Craft 3 automatically if you supply the appropriate configuration.