### PR TITLE
Added Steadfast Design Firm's staging domain

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -77,6 +77,7 @@ return [
     'staging-site.link',
     'stagingbox.ca',
     'stagingbox.co.uk',
+    'steadfa.st',
     'tad.am',
     'testsite.no',
     'the-neighbourhood-production.com',


### PR DESCRIPTION
At [Steadfast Design Firm](https://www.steadfastdesignfirm.com/) we use the domain `steadfa.st` as a staging platform for client sites before they go live. It would be swell if we could remove the license check errors for our domain. Thanks!