### PR TITLE
 Add condition parameter to actionList()

### DIFF
--- a/src/controllers/api/v1/PluginLicensesController.php
+++ b/src/controllers/api/v1/PluginLicensesController.php
@@ -33,11 +33,12 @@ class PluginLicensesController extends BaseApiController
      *
      * @param int|null $page
      * @param int|null $perPage
+     * @param string|array|null $condition
      * @return Response
      * @throws BadRequestHttpException if the `page` or `perPage` params are set but not integers
      * @throws UnauthorizedHttpException
      */
-    public function actionList($page = null, $perPage = null): Response
+    public function actionList($page = null, $perPage = null, $condition = null): Response
     {
         if (($user = Craft::$app->getUser()->getIdentity(false)) === null) {
             throw new UnauthorizedHttpException('Not Authorized');
@@ -53,7 +54,7 @@ class PluginLicensesController extends BaseApiController
         $perPage = $perPage ? (int)$perPage : 100;
 
         list($offset, $limit) = $this->page2offset($page, $perPage);
-        $licenses = $this->module->getPluginLicenseManager()->getLicensesByDeveloper($user->id, $offset, $limit, $total);
+        $licenses = $this->module->getPluginLicenseManager()->getLicensesByDeveloper($user->id, $offset, $limit, $total, $condition);
         return $this->asJson([
             'total' => $total,
             'totalPages' => ceil($total / $limit),

--- a/src/plugins/PluginLicenseManager.php
+++ b/src/plugins/PluginLicenseManager.php
@@ -236,13 +236,15 @@ class PluginLicenseManager extends Component
      * @param int|null $offset
      * @param int|null $limit
      * @param int|null $total
+     * @param string|array|null $condition
      * @return PluginLicense[]
      */
-    public function getLicensesByDeveloper(int $developerId, int $offset = null, int $limit = null, int &$total = null): array
+    public function getLicensesByDeveloper(int $developerId, int $offset = null, int $limit = null, int &$total = null, $condition = null): array
     {
         $query = $this->_createLicenseQuery()
             ->innerJoin('craftnet_plugins p', '[[p.id]] = [[l.pluginId]]')
             ->where(['p.developerId' => $developerId]);
+            ->andWhere($condition);
 
         $total = $query->count();
         $results = $query


### PR DESCRIPTION
Adding a `condition` parameter will allow us to fetch plugin licenses in a much more fine-grained way than simply by page number. At the very least it will allow us to use the API to efficiently create sales reports and statistics which would be extremely helpful.

Sample usage:

```
$client = new GuzzleHttp\Client();
$response = $client->request('GET', 'https://api.craftcms.com/v1/plugin-licenses', [
    'auth' => ['putyourlightson', 'qwoiuyghj3ebb7mp8r762h7dn8htstx8xsl7ou7'],
    'query' => [
        'condition' => [
            'plugin' => 'blitz',
            ['>', 'dateCreated', '2019-01-01'],
        ],
    ],
]);
```