### PR TITLE
Added isted.dev staging domain

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -40,6 +40,7 @@ return [
     'hpsmartdev.com',
     'hyperlane.co',
     'infomedia-dev.com',
+    'isted.dev',
     'lndo.site',
     'madebymasuga.com',
     'madebyshape-dev.co.uk',


### PR DESCRIPTION
isted.dev is used as a staging domain for freelance projects by isted.me, it would help the workflow if this could be added to the whitelist. Thanks