### PR TITLE
Add `servd.dev` to whitelisted domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -71,6 +71,7 @@ return [
     'psclients.net',
     'rantsports.org',
     'sandboxdsm.com',
+    'servd.dev',
     'sib.nz',
     'siebirdclients.com',
     'siebirdstaging.com',


### PR DESCRIPTION
The domain used for Servd.host vanity URLs 👌