### PR TITLE
Adds MIDDAG staging domain

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -67,6 +67,7 @@ return [
     'nxcli.net',
     'ondev.co',
     'oneis.us',
+    'ontwikkeling.site',
     'our-staging-server.net',
     'preview.dev',
     'preview-it.com',


### PR DESCRIPTION
As discussed with Oli from Pixel & Tonic: this PR adds our generic staging domain `ontwikkeling.site` to the whitelist so that it can be used for development without having to handle licensing issues.