### PR TITLE
Mark HTML attributes Craft 2 plugin with specific upgrade guidance

### DIFF
--- a/config/craft2-plugins.php
+++ b/config/craft2-plugins.php
@@ -242,6 +242,10 @@ return [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [Guide](https://github.com/wbrowar/craft-3-guide) can be used instead.'
     ],
+    'HtmlAttributes' => [
+        'statusColor' => 'orange',
+        'status' => 'No longer needed thanks to Craft 3’s `attr()` Twig function.'
+    ],
     'Htmlcache' => [
         'statusColor' => 'orange',
         'status' => 'Not available yet, but [HTML Cache](https://github.com/boldenamsterdam/htmlcache) can be used instead.'


### PR DESCRIPTION
The Craft 2 plugin functionality is part of Craft CMS 3.2 using Yii `yii\helpers\BaseHtml::renderTagAttributes` now.

https://docs.craftcms.com/v3/dev/functions.html#attr
https://github.com/craftcms/cms/pull/4237

This provides specific Craft 3 upgrade guidance if this plugin is being used on a Craft 2 site.