### PR TITLE
Whitelist putyourlightson.dev

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -83,6 +83,7 @@ return [
     'preview.dev',
     'preview-it.com',
     'psclients.net',
+    'putyourlightson.dev',
     'rantsports.org',
     'runcloud.site',
     'sandboxdsm.com',


### PR DESCRIPTION
We use `putyourlightson.dev` for hosting sites in development at https://putyourlightson.com/. Thanks in advance!