### PR TITLE
Add `miranj.dev` to dev-domains list

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -59,6 +59,7 @@ return [
     'martinleveille.dev',
     'mcipreview.com',
     'microserve-staging.ca',
+    'miranj.dev',
     'mldev.net',
     'mock-up.ca',
     'modlabdev.com',


### PR DESCRIPTION
We’re using `miranj.dev` as a staging domain for [Miranj](https://miranj.in) client sites. Please add it to the exclude list.