### PR TITLE
Add Moresoda development/testing domain

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -65,6 +65,7 @@ return [
     'mldev.net',
     'mock-up.ca',
     'modlabdev.com',
+    'ms-stage.co.uk',
     'mstesting.com.au',
     'mystagingsite.org',
     'mystagingsite.us',


### PR DESCRIPTION
Moresoda (https://moresoda.co.uk) frequently use *.ms-stage.co.uk domains for client approval/staging sites. Can it be added to this list please?


