### PR TITLE
Refactor table references

### DIFF
--- a/migrations/m180318_222158_create_license_tables.php
+++ b/migrations/m180318_222158_create_license_tables.php
@@ -7,6 +7,9 @@ use craft\db\Migration;
 use craft\db\Query;
 use craftnet\cms\CmsEdition;
 use craftnet\cms\CmsRenewal;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
+use craft\commerce\db\Table as CommerceTable;
 use craftnet\plugins\PluginEdition;
 use craftnet\plugins\PluginRenewal;
 use yii\console\Exception;
@@ -40,12 +43,12 @@ class m180318_222158_create_license_tables extends Migration
     {
         // fix plugins table ---------------------------------------------------
 
-        $this->alterColumn('craftnet_plugins', 'price', $this->decimal(14, 4)->unsigned());
-        $this->alterColumn('craftnet_plugins', 'renewalPrice', $this->decimal(14, 4)->unsigned());
+        $this->alterColumn(Table::PLUGINS, 'price', $this->decimal(14, 4)->unsigned());
+        $this->alterColumn(Table::PLUGINS, 'renewalPrice', $this->decimal(14, 4)->unsigned());
 
         // cmseditions ---------------------------------------------------------
 
-        $this->createTable('craftnet_cmseditions', [
+        $this->createTable(Table::CMSEDITIONS, [
             'id' => $this->integer()->notNull(),
             'name' => $this->string()->notNull(),
             'handle' => $this->string()->notNull(),
@@ -54,27 +57,27 @@ class m180318_222158_create_license_tables extends Migration
             'PRIMARY KEY([[id]])',
         ]);
 
-        $this->createIndex(null, 'craftnet_cmseditions', ['name'], true);
-        $this->createIndex(null, 'craftnet_cmseditions', ['handle'], true);
-        $this->createIndex(null, 'craftnet_cmseditions', ['price']);
+        $this->createIndex(null, Table::CMSEDITIONS, ['name'], true);
+        $this->createIndex(null, Table::CMSEDITIONS, ['handle'], true);
+        $this->createIndex(null, Table::CMSEDITIONS, ['price']);
 
-        $this->addForeignKey(null, 'craftnet_cmseditions', ['id'], 'elements', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSEDITIONS, ['id'], CraftTable::ELEMENTS, ['id'], 'CASCADE');
 
         // cmsrenewals ---------------------------------------------------------
 
-        $this->createTable('craftnet_cmsrenewals', [
+        $this->createTable(Table::CMSRENEWALS, [
             'id' => $this->integer()->notNull(),
             'editionId' => $this->integer()->notNull(),
             'price' => $this->decimal(14, 4)->unsigned()->notNull(),
             'PRIMARY KEY([[id]])',
         ]);
 
-        $this->addForeignKey(null, 'craftnet_cmsrenewals', ['id'], 'elements', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_cmsrenewals', ['editionId'], 'craftnet_cmseditions', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSRENEWALS, ['id'], CraftTable::ELEMENTS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSRENEWALS, ['editionId'], Table::CMSEDITIONS, ['id'], 'CASCADE');
 
         // cmslicenses ---------------------------------------------------------
 
-        $this->createTable('craftnet_cmslicenses', [
+        $this->createTable(Table::CMSLICENSES, [
             'id' => $this->primaryKey(),
             'editionId' => $this->integer()->notNull(),
             'ownerId' => $this->integer()->null(),
@@ -98,37 +101,37 @@ class m180318_222158_create_license_tables extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->createIndex(null, 'craftnet_cmslicenses', ['key'], true);
-        $this->createIndex($this->db->getIndexName('craftnet_cmslicenses', ['ownerId', 'email']), 'craftnet_cmslicenses', ['ownerId', 'lower([[email]])']);
+        $this->createIndex(null, Table::CMSLICENSES, ['key'], true);
+        $this->createIndex($this->db->getIndexName(Table::CMSLICENSES, ['ownerId', 'email']), Table::CMSLICENSES, ['ownerId', 'lower([[email]])']);
 
-        $this->addForeignKey(null, 'craftnet_cmslicenses', ['editionId'], 'craftnet_cmseditions', ['id']);
-        $this->addForeignKey(null, 'craftnet_cmslicenses', ['ownerId'], 'users', ['id'], 'SET NULL');
+        $this->addForeignKey(null, Table::CMSLICENSES, ['editionId'], Table::CMSEDITIONS, ['id']);
+        $this->addForeignKey(null, Table::CMSLICENSES, ['ownerId'], CraftTable::USERS, ['id'], 'SET NULL');
 
         // cmslicensehistory ---------------------------------------------------
 
-        $this->createTable('craftnet_cmslicensehistory', [
+        $this->createTable(Table::CMSLICENSEHISTORY, [
             'id' => $this->bigPrimaryKey(),
             'licenseId' => $this->integer(),
             'note' => $this->string()->notNull(),
             'timestamp' => $this->dateTime()->notNull(),
         ]);
 
-        $this->addForeignKey(null, 'craftnet_cmslicensehistory', ['licenseId'], 'craftnet_cmslicenses', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSLICENSEHISTORY, ['licenseId'], Table::CMSLICENSES, ['id'], 'CASCADE');
 
         // cmslicenses_lineitems -----------------------------------------------
 
-        $this->createTable('craftnet_cmslicenses_lineitems', [
+        $this->createTable(Table::CMSLICENSES_LINEITEMS, [
             'licenseId' => $this->integer()->notNull(),
             'lineItemId' => $this->integer()->notNull(),
             'PRIMARY KEY([[licenseId]], [[lineItemId]])',
         ]);
 
-        $this->addForeignKey(null, 'craftnet_cmslicenses_lineitems', ['licenseId'], 'craftnet_cmslicenses', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_cmslicenses_lineitems', ['lineItemId'], 'commerce_lineitems', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSLICENSES_LINEITEMS, ['licenseId'], Table::CMSLICENSES, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSLICENSES_LINEITEMS, ['lineItemId'], CommerceTable::LINEITEMS, ['id'], 'CASCADE');
 
         // inactivecmslicenses -------------------------------------------------
 
-        $this->createTable('craftnet_inactivecmslicenses', [
+        $this->createTable(Table::INACTIVECMSLICENSES, [
             'key' => $this->string(250)->notNull(),
             'data' => $this->text(),
             'PRIMARY KEY([[key]])',
@@ -139,7 +142,7 @@ class m180318_222158_create_license_tables extends Migration
     {
         // plugineditions ------------------------------------------------------
 
-        $this->createTable('craftnet_plugineditions', [
+        $this->createTable(Table::PLUGINEDITIONS, [
             'id' => $this->integer()->notNull(),
             'pluginId' => $this->integer()->notNull(),
             'name' => $this->string()->notNull(),
@@ -149,16 +152,16 @@ class m180318_222158_create_license_tables extends Migration
             'PRIMARY KEY([[id]])',
         ]);
 
-        $this->createIndex(null, 'craftnet_plugineditions', ['pluginId', 'name'], true);
-        $this->createIndex(null, 'craftnet_plugineditions', ['pluginId', 'handle'], true);
-        $this->createIndex(null, 'craftnet_plugineditions', ['pluginId', 'price']);
+        $this->createIndex(null, Table::PLUGINEDITIONS, ['pluginId', 'name'], true);
+        $this->createIndex(null, Table::PLUGINEDITIONS, ['pluginId', 'handle'], true);
+        $this->createIndex(null, Table::PLUGINEDITIONS, ['pluginId', 'price']);
 
-        $this->addForeignKey(null, 'craftnet_plugineditions', ['id'], 'elements', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_plugineditions', ['pluginId'], 'craftnet_plugins', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINEDITIONS, ['id'], CraftTable::ELEMENTS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINEDITIONS, ['pluginId'], Table::PLUGINS, ['id'], 'CASCADE');
 
         // cmsrenewals ---------------------------------------------------------
 
-        $this->createTable('craftnet_pluginrenewals', [
+        $this->createTable(Table::PLUGINRENEWALS, [
             'id' => $this->integer()->notNull(),
             'pluginId' => $this->integer()->notNull(),
             'editionId' => $this->integer()->notNull(),
@@ -166,13 +169,13 @@ class m180318_222158_create_license_tables extends Migration
             'PRIMARY KEY([[id]])',
         ]);
 
-        $this->addForeignKey(null, 'craftnet_pluginrenewals', ['id'], 'elements', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_pluginrenewals', ['pluginId'], 'craftnet_plugins', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_pluginrenewals', ['editionId'], 'craftnet_plugineditions', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINRENEWALS, ['id'], CraftTable::ELEMENTS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINRENEWALS, ['pluginId'], Table::PLUGINS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINRENEWALS, ['editionId'], Table::PLUGINEDITIONS, ['id'], 'CASCADE');
 
         // pluginlicenses ------------------------------------------------------
 
-        $this->createTable('craftnet_pluginlicenses', [
+        $this->createTable(Table::PLUGINLICENSES, [
             'id' => $this->primaryKey(),
             'pluginId' => $this->integer()->notNull(),
             'editionId' => $this->integer()->notNull(),
@@ -197,35 +200,35 @@ class m180318_222158_create_license_tables extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->createIndex(null, 'craftnet_pluginlicenses', ['key'], true);
-        $this->createIndex($this->db->getIndexName('craftnet_pluginlicenses', ['ownerId', 'email']), 'craftnet_pluginlicenses', ['ownerId', 'lower([[email]])']);
+        $this->createIndex(null, Table::PLUGINLICENSES, ['key'], true);
+        $this->createIndex($this->db->getIndexName(Table::PLUGINLICENSES, ['ownerId', 'email']), Table::PLUGINLICENSES, ['ownerId', 'lower([[email]])']);
 
-        $this->addForeignKey(null, 'craftnet_pluginlicenses', ['pluginId'], 'craftnet_plugins', ['id']);
-        $this->addForeignKey(null, 'craftnet_pluginlicenses', ['editionId'], 'craftnet_plugineditions', ['id']);
-        $this->addForeignKey(null, 'craftnet_pluginlicenses', ['cmsLicenseId'], 'craftnet_cmslicenses', ['id'], 'SET NULL');
-        $this->addForeignKey(null, 'craftnet_pluginlicenses', ['ownerId'], 'users', ['id'], 'SET NULL');
+        $this->addForeignKey(null, Table::PLUGINLICENSES, ['pluginId'], Table::PLUGINS, ['id']);
+        $this->addForeignKey(null, Table::PLUGINLICENSES, ['editionId'], Table::PLUGINEDITIONS, ['id']);
+        $this->addForeignKey(null, Table::PLUGINLICENSES, ['cmsLicenseId'], Table::CMSLICENSES, ['id'], 'SET NULL');
+        $this->addForeignKey(null, Table::PLUGINLICENSES, ['ownerId'], CraftTable::USERS, ['id'], 'SET NULL');
 
         // pluginlicensehistory ------------------------------------------------
 
-        $this->createTable('craftnet_pluginlicensehistory', [
+        $this->createTable(Table::PLUGINLICENSEHISTORY, [
             'id' => $this->bigPrimaryKey(),
             'licenseId' => $this->integer(),
             'note' => $this->string()->notNull(),
             'timestamp' => $this->dateTime()->notNull(),
         ]);
 
-        $this->addForeignKey(null, 'craftnet_pluginlicensehistory', ['licenseId'], 'craftnet_pluginlicenses', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINLICENSEHISTORY, ['licenseId'], Table::PLUGINLICENSES, ['id'], 'CASCADE');
 
         // pluginlicenses_lineitems --------------------------------------------
 
-        $this->createTable('craftnet_pluginlicenses_lineitems', [
+        $this->createTable(Table::PLUGINLICENSES_LINEITEMS, [
             'licenseId' => $this->integer()->notNull(),
             'lineItemId' => $this->integer()->notNull(),
             'PRIMARY KEY([[licenseId]], [[lineItemId]])',
         ]);
 
-        $this->addForeignKey(null, 'craftnet_pluginlicenses_lineitems', ['licenseId'], 'craftnet_pluginlicenses', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_pluginlicenses_lineitems', ['lineItemId'], 'commerce_lineitems', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINLICENSES_LINEITEMS, ['licenseId'], Table::PLUGINLICENSES, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PLUGINLICENSES_LINEITEMS, ['lineItemId'], CommerceTable::LINEITEMS, ['id'], 'CASCADE');
     }
 
     private function _createCmsEditions()
@@ -278,7 +281,7 @@ class m180318_222158_create_license_tables extends Migration
 
         $plugins = (new Query())
             ->select(['id', 'name', 'price', 'renewalPrice'])
-            ->from('craftnet_plugins')
+            ->from(Table::PLUGINS)
             ->all();
 
         foreach ($plugins as $plugin) {

--- a/migrations/m180318_222228_developer_tables.php
+++ b/migrations/m180318_222228_developer_tables.php
@@ -4,6 +4,8 @@ namespace craft\contentmigrations;
 
 use craft\db\Migration;
 use craft\elements\User;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
 
 /**
  * m180318_222228_developer_tables migration.
@@ -16,7 +18,7 @@ class m180318_222228_developer_tables extends Migration
     public function safeUp()
     {
         // developers table
-        $this->createTable('craftnet_developers', [
+        $this->createTable(Table::DEVELOPERS, [
             'id' => $this->integer()->notNull(),
             'country' => $this->char(2)->null(),
             'balance' => $this->decimal(14, 4)->notNull()->defaultValue(0),
@@ -27,10 +29,10 @@ class m180318_222228_developer_tables extends Migration
             'PRIMARY KEY([[id]])',
         ]);
 
-        $this->addForeignKey(null, 'craftnet_developers', ['id'], '{{%users}}', ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::DEVELOPERS, ['id'], CraftTable::USERS, ['id'], 'CASCADE', null);
 
         // developerledger
-        $this->createTable('craftnet_developerledger', [
+        $this->createTable(Table::DEVELOPERLEDGER, [
             'id' => $this->bigPrimaryKey(),
             'developerId' => $this->integer(),
             'note' => $this->string(),
@@ -41,7 +43,7 @@ class m180318_222228_developer_tables extends Migration
             'dateCreated' => $this->dateTime()->notNull(),
         ]);
 
-        $this->addForeignKey(null, 'craftnet_developerledger', ['developerId'], 'craftnet_developers', ['id'], 'CASCADE', null);
+        $this->addForeignKey(null, Table::DEVELOPERLEDGER, ['developerId'], Table::DEVELOPERS, ['id'], 'CASCADE', null);
 
         // add initial rows
         $developerIds = User::find()
@@ -55,7 +57,7 @@ class m180318_222228_developer_tables extends Migration
             $developerValues[] = [$id];
         }
 
-        $this->batchInsert('craftnet_developers', ['id'], $developerValues, false);
+        $this->batchInsert(Table::DEVELOPERS, ['id'], $developerValues, false);
     }
 
     /**

--- a/migrations/m180323_201227_ledger_tweaks.php
+++ b/migrations/m180323_201227_ledger_tweaks.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m180323_201227_ledger_tweaks migration.
@@ -14,9 +15,9 @@ class m180323_201227_ledger_tweaks extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_developerledger', 'type', $this->string()->null());
-        $this->addColumn('craftnet_developerledger', 'country', $this->char(2)->null());
-        $this->addColumn('craftnet_developerledger', 'isEuMember', $this->boolean()->null());
+        $this->addColumn(Table::DEVELOPERLEDGER, 'type', $this->string()->null());
+        $this->addColumn(Table::DEVELOPERLEDGER, 'country', $this->char(2)->null());
+        $this->addColumn(Table::DEVELOPERLEDGER, 'isEuMember', $this->boolean()->null());
     }
 
     /**

--- a/migrations/m180323_201249_email_codes.php
+++ b/migrations/m180323_201249_email_codes.php
@@ -3,6 +3,8 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
 
 /**
  * m180323_201249_email_codes migration.
@@ -14,7 +16,7 @@ class m180323_201249_email_codes extends Migration
      */
     public function safeUp()
     {
-        $this->createTable('craftnet_emailcodes', [
+        $this->createTable(Table::EMAILCODES, [
             'id' => $this->primaryKey(),
             'userId' => $this->integer(),
             'email' => $this->string()->notNull(),
@@ -22,9 +24,9 @@ class m180323_201249_email_codes extends Migration
             'dateIssued' => $this->dateTime()->notNull(),
         ]);
 
-        $this->addForeignKey(null, 'craftnet_emailcodes', ['userId'], 'users', ['id'], 'CASCADE');
-        $this->createIndex(null, 'craftnet_emailcodes', ['userId', 'email']);
-        $this->createIndex(null, 'craftnet_emailcodes', ['dateIssued']);
+        $this->addForeignKey(null, Table::EMAILCODES, ['userId'], CraftTable::USERS, ['id'], 'CASCADE');
+        $this->createIndex(null, Table::EMAILCODES, ['userId', 'email']);
+        $this->createIndex(null, Table::EMAILCODES, ['dateIssued']);
     }
 
     /**

--- a/migrations/m180402_204534_rename_license_handle_columns.php
+++ b/migrations/m180402_204534_rename_license_handle_columns.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m180402_204534_rename_license_handle_columns migration.
@@ -14,8 +15,8 @@ class m180402_204534_rename_license_handle_columns extends Migration
      */
     public function safeUp()
     {
-        $this->renameColumn('craftnet_cmslicenses', 'edition', 'editionHandle');
-        $this->renameColumn('craftnet_pluginlicenses', 'plugin', 'pluginHandle');
+        $this->renameColumn(Table::CMSLICENSES, 'edition', 'editionHandle');
+        $this->renameColumn(Table::PLUGINLICENSES, 'plugin', 'pluginHandle');
     }
 
     /**

--- a/migrations/m180403_023338_edition_changes.php
+++ b/migrations/m180403_023338_edition_changes.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\db\Migration;
 use craft\db\Query;
 use craftnet\cms\CmsEdition;
+use craftnet\db\Table;
 use craftnet\Module;
 
 /**
@@ -34,7 +35,7 @@ class m180403_023338_edition_changes extends Migration
 
         echo "    > updating Solo licenses' edition handles ...";
         Craft::$app->getDb()->createCommand()
-            ->update('craftnet_cmslicenses', [
+            ->update(Table::CMSLICENSES, [
                 'editionHandle' => 'solo'
             ], [
                 'editionId' => $editions['personal']->id
@@ -44,7 +45,7 @@ class m180403_023338_edition_changes extends Migration
 
         $clientLicenseQuery = (new Query())
             ->select(['id'])
-            ->from(['craftnet_cmslicenses'])
+            ->from([Table::CMSLICENSES])
             ->where(['editionId' => $editions['client']->id]);
         echo "    > upgrading {$clientLicenseQuery->count()} Client licenses ...\n";
 

--- a/migrations/m180410_162242_unique_packageName_constraint.php
+++ b/migrations/m180410_162242_unique_packageName_constraint.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m180410_162242_unique_packageName_constraint migration.
@@ -14,7 +15,7 @@ class m180410_162242_unique_packageName_constraint extends Migration
      */
     public function safeUp()
     {
-        $this->createIndex(null, 'craftnet_plugins', ['packageName'], true);
+        $this->createIndex(null, Table::PLUGINS, ['packageName'], true);
     }
 
     /**

--- a/migrations/m180502_180541_fix_plugin_license_expiry_dates.php
+++ b/migrations/m180502_180541_fix_plugin_license_expiry_dates.php
@@ -7,6 +7,7 @@ use craft\db\Query;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\Json;
+use craftnet\db\Table;
 
 /**
  * m180502_180541_fix_plugin_license_expiry_dates migration.
@@ -30,7 +31,7 @@ class m180502_180541_fix_plugin_license_expiry_dates extends Migration
             $body = Json::decode($request['body']);
             $licenseId = (new Query())
                 ->select(['id'])
-                ->from('craftnet_pluginlicenses')
+                ->from(Table::PLUGINLICENSES)
                 ->where([
                     'pluginHandle' => $body['plugin'],
                     'email' => $body['email'],
@@ -48,7 +49,7 @@ class m180502_180541_fix_plugin_license_expiry_dates extends Migration
             $expiresOn = DateTimeHelper::toDateTime($body['expiresOn']);
             $expiresOnSql = Db::prepareDateForDb($expiresOn);
             echo "    > setting expiry date for license {$licenseId} to {$expiresOnSql}\n";
-            $this->update('craftnet_pluginlicenses', [
+            $this->update(Table::PLUGINLICENSES, [
                 'expiresOn' => $expiresOnSql
             ], [
                 'id' => $licenseId,

--- a/migrations/m180724_195341_create_partners_tables.php
+++ b/migrations/m180724_195341_create_partners_tables.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m180724_195341_create_partners_tables migration.
@@ -14,7 +15,7 @@ class m180724_195341_create_partners_tables extends Migration
      */
     public function safeUp()
     {
-        $this->createTable('craftnet_partners', [
+        $this->createTable(Table::PARTNERS, [
             'id' => $this->integer()->notNull(),
             'ownerId' => $this->integer()->notNull(),
             'businessName' => $this->string(),
@@ -33,52 +34,52 @@ class m180724_195341_create_partners_tables extends Migration
         // Sizes ---------------------------------------------------------------
 
         // Holds available options
-        $this->createTable('craftnet_partnersizes', [
+        $this->createTable(Table::PARTNERSIZES, [
             'id' => $this->primaryKey(),
             'title' => $this->string()->notNull(),
         ]);
 
-        $this->batchInsert('craftnet_partnersizes', ['id', 'title'], [
+        $this->batchInsert(Table::PARTNERSIZES, ['id', 'title'], [
             [1, 'Boutique'],
             [2, 'Agency'],
             [3, 'Large Agency'],
         ], false);
 
         // Join table
-        $this->createTable('craftnet_partners_partnersizes', [
+        $this->createTable(Table::PARTNERS_PARTNERSIZES, [
             'partnerId' => $this->integer()->notNull(),
             'partnerSizesId' => $this->integer()->notNull(),
             'PRIMARY KEY([[partnerId]], [[partnerSizesId]])',
         ]);
 
-        $this->addForeignKey('craftnet_partners_partnersizes_partnerId_fk', 'craftnet_partners_partnersizes', ['partnerId'], 'craftnet_partners', ['id'], 'CASCADE');
+        $this->addForeignKey('craftnet_partners_partnersizes_partnerId_fk', Table::PARTNERS_PARTNERSIZES, ['partnerId'], Table::PARTNERS, ['id'], 'CASCADE');
 
         // Capabilities --------------------------------------------------------
 
-        $this->createTable('craftnet_partnercapabilities', [
+        $this->createTable(Table::PARTNERCAPABILITIES, [
             'id' => $this->primaryKey(),
             'title' => $this->string()->notNull(),
         ]);
 
-        $this->batchInsert('craftnet_partnercapabilities', ['id', 'title'], [
+        $this->batchInsert(Table::PARTNERCAPABILITIES, ['id', 'title'], [
             [1, 'Commerce'],
             [2, 'Full Service'],
             [3, 'Custom Development'],
             [4, 'Contract Work'],
         ], false);
 
-        $this->createTable('craftnet_partners_partnercapabilities', [
+        $this->createTable(Table::PARTNERS_PARTNERCAPABILITIES, [
             'partnerId' => $this->integer()->notNull(),
             'partnercapabilitiesId' => $this->integer()->notNull(),
             'PRIMARY KEY([[partnerId]], [[partnercapabilitiesId]])',
         ]);
 
-        $this->addForeignKey('partners_capabilities_partnerId_fk', 'craftnet_partners_partnercapabilities', ['partnerId'], 'craftnet_partners', ['id'], 'CASCADE');
-        $this->addForeignKey('partners_capabilities_partnercapabilitiesId_fk', 'craftnet_partners_partnercapabilities', ['partnercapabilitiesId'], 'craftnet_partnercapabilities', ['id'], 'CASCADE');
+        $this->addForeignKey('partners_capabilities_partnerId_fk', Table::PARTNERS_PARTNERCAPABILITIES, ['partnerId'], Table::PARTNERS, ['id'], 'CASCADE');
+        $this->addForeignKey('partners_capabilities_partnercapabilitiesId_fk', Table::PARTNERS_PARTNERCAPABILITIES, ['partnercapabilitiesId'], Table::PARTNERCAPABILITIES, ['id'], 'CASCADE');
 
         // Locations -----------------------------------------------------------
 
-        $this->createTable('craftnet_partnerlocations', [
+        $this->createTable(Table::PARTNERLOCATIONS, [
             'id' => $this->primaryKey(),
             'partnerId' => $this->integer()->notNull(),
             'title' => $this->string(),
@@ -95,11 +96,11 @@ class m180724_195341_create_partners_tables extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->addForeignKey('craftnet_partnerlocations_partnerId_fk', 'craftnet_partnerlocations', ['partnerId'], 'craftnet_partners', ['id'], 'CASCADE');
+        $this->addForeignKey('craftnet_partnerlocations_partnerId_fk', Table::PARTNERLOCATIONS, ['partnerId'], Table::PARTNERS, ['id'], 'CASCADE');
 
         // Projects ------------------------------------------------------------
 
-        $this->createTable('craftnet_partnerprojects', [
+        $this->createTable(Table::PARTNERPROJECTS, [
             'id' => $this->primaryKey(),
             'partnerId' => $this->integer()->notNull(),
             'url' => $this->string(),
@@ -109,9 +110,9 @@ class m180724_195341_create_partners_tables extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->addForeignKey('craftnet_partnerprojects_partnerId_fk', 'craftnet_partnerprojects', ['partnerId'], 'craftnet_partners', ['id'], 'CASCADE');
+        $this->addForeignKey('craftnet_partnerprojects_partnerId_fk', Table::PARTNERPROJECTS, ['partnerId'], Table::PARTNERS, ['id'], 'CASCADE');
 
-        $this->createTable('craftnet_partnerprojectscreenshots', [
+        $this->createTable(Table::PARTNERPROJECTSCREENSHOTS, [
             'id' => $this->primaryKey(),
             'projectId' => $this->integer()->notNull(),
             'assetId' => $this->integer()->notNull(),
@@ -121,7 +122,7 @@ class m180724_195341_create_partners_tables extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->addForeignKey('craftnet_partnerprojectscreenshots_projectId_fk', 'craftnet_partnerprojectscreenshots', ['projectId'], 'craftnet_partnerprojects', ['id'], 'CASCADE');
+        $this->addForeignKey('craftnet_partnerprojectscreenshots_projectId_fk', Table::PARTNERPROJECTSCREENSHOTS, ['projectId'], Table::PARTNERPROJECTS, ['id'], 'CASCADE');
     }
 
     /**
@@ -133,13 +134,13 @@ class m180724_195341_create_partners_tables extends Migration
 //        return false;
 
         // TODO: remove droptables when ready
-        $this->dropTable('craftnet_partners_partnersizes');
-        $this->dropTable('craftnet_partnersizes');
-        $this->dropTable('craftnet_partners_partnercapabilities');
-        $this->dropTable('craftnet_partnercapabilities');
-        $this->dropTable('craftnet_partnerlocations');
-        $this->dropTable('craftnet_partnerprojectscreenshots');
-        $this->dropTable('craftnet_partnerprojects');
-        $this->dropTable('craftnet_partners');
+        $this->dropTable(Table::PARTNERS_PARTNERSIZES);
+        $this->dropTable(Table::PARTNERSIZES);
+        $this->dropTable(Table::PARTNERS_PARTNERCAPABILITIES);
+        $this->dropTable(Table::PARTNERCAPABILITIES);
+        $this->dropTable(Table::PARTNERLOCATIONS);
+        $this->dropTable(Table::PARTNERPROJECTSCREENSHOTS);
+        $this->dropTable(Table::PARTNERPROJECTS);
+        $this->dropTable(Table::PARTNERS);
     }
 }

--- a/migrations/m180831_214018_change_partner_msa_to_asset.php
+++ b/migrations/m180831_214018_change_partner_msa_to_asset.php
@@ -4,6 +4,7 @@ namespace craft\contentmigrations;
 
 use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m180831_214018_change_parter_msa_column_type migration.
@@ -35,7 +36,7 @@ class m180831_214018_change_partner_msa_to_asset extends Migration
      */
     protected function createMsaAssetIdColumn()
     {
-        $schema = $this->db->getTableSchema('craftnet_partners');
+        $schema = $this->db->getTableSchema(Table::PARTNERS);
 
         // If this migration has already run then skip it
         if ($schema->getColumn('msaAssetId')) {
@@ -43,8 +44,8 @@ class m180831_214018_change_partner_msa_to_asset extends Migration
             return true;
         }
 
-        $this->addColumn('craftnet_partners', 'msaAssetId', $this->integer()->after('msaLink'));
-        $this->dropColumn('craftnet_partners', 'msaLink');
+        $this->addColumn(Table::PARTNERS, 'msaAssetId', $this->integer()->after('msaLink'));
+        $this->dropColumn(Table::PARTNERS, 'msaLink');
     }
 
     /**

--- a/migrations/m180904_214847_create_partnerhistory_table.php
+++ b/migrations/m180904_214847_create_partnerhistory_table.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m180904_214847_create_partnerhistory_table migration.
@@ -14,7 +15,7 @@ class m180904_214847_create_partnerhistory_table extends Migration
      */
     public function safeUp()
     {
-        $this->createTable('craftnet_partnerhistory', [
+        $this->createTable(Table::PARTNERHISTORY, [
             'id' => $this->primaryKey(),
             'authorId' => $this->integer(),
             'partnerId' => $this->integer()->notNull(),
@@ -24,7 +25,7 @@ class m180904_214847_create_partnerhistory_table extends Migration
             'uid' => $this->uid(),
         ]);
 
-        $this->addForeignKey(null, 'craftnet_partnerhistory', ['partnerId'], 'craftnet_partners', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PARTNERHISTORY, ['partnerId'], Table::PARTNERS, ['id'], 'CASCADE');
     }
 
     /**
@@ -32,7 +33,7 @@ class m180904_214847_create_partnerhistory_table extends Migration
      */
     public function safeDown()
     {
-        $this->dropTableIfExists('craftnet_partnerhistory');
+        $this->dropTableIfExists(Table::PARTNERHISTORY);
         return true;
     }
 }

--- a/migrations/m180912_040313_reactivate_all_cmslicenses.php
+++ b/migrations/m180912_040313_reactivate_all_cmslicenses.php
@@ -8,6 +8,7 @@ use craft\db\Query;
 use craft\helpers\Console;
 use craft\helpers\Json;
 use craftnet\cms\CmsLicense;
+use craftnet\db\Table;
 use craftnet\Module;
 
 /**
@@ -27,7 +28,7 @@ class m180912_040313_reactivate_all_cmslicenses extends Migration
 
         $query = (new Query())
             ->select(['key', 'data'])
-            ->from(['craftnet_inactivecmslicenses'])
+            ->from([Table::INACTIVECMSLICENSES])
             ->limit(1000);
 
         $cmsLicenseManager = Module::getInstance()->getCmsLicenseManager();
@@ -47,7 +48,7 @@ class m180912_040313_reactivate_all_cmslicenses extends Migration
                 Console::stdout('deleting inactive row ... ');
 
                 Craft::$app->getDb()->createCommand()
-                    ->delete('craftnet_inactivecmslicenses', [
+                    ->delete(Table::INACTIVECMSLICENSES, [
                         'key' => $result['key']
                     ])
                     ->execute();
@@ -64,7 +65,7 @@ class m180912_040313_reactivate_all_cmslicenses extends Migration
             }
         } while (!empty($results));
 
-        $this->dropTable('craftnet_inactivecmslicenses');
+        $this->dropTable(Table::INACTIVECMSLICENSES);
     }
 
     /**

--- a/migrations/m181018_162119_add__more_partner_columns.php
+++ b/migrations/m181018_162119_add__more_partner_columns.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181018_162119_add__more_partner_columns migration.
@@ -15,25 +16,25 @@ class m181018_162119_add__more_partner_columns extends Migration
     public function safeUp()
     {
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'hasFullTimeDev',
             $this->boolean()->defaultValue(false)->after('minimumBudget')
         );
 
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'isCraftVerified',
             $this->boolean()->defaultValue(false)->after('hasFullTimeDev')
         );
 
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'isCommerceVerified',
             $this->boolean()->defaultValue(false)->after('isCraftVerified')
         );
 
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'isEnterpriseVerified',
             $this->boolean()->defaultValue(false)->after('isCommerceVerified')
         );
@@ -44,10 +45,10 @@ class m181018_162119_add__more_partner_columns extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partners', 'hasFullTimeDev');
-        $this->dropColumn('craftnet_partners', 'isCraftVerified');
-        $this->dropColumn('craftnet_partners', 'isCommerceVerified');
-        $this->dropColumn('craftnet_partners', 'isEnterpriseVerified');
+        $this->dropColumn(Table::PARTNERS, 'hasFullTimeDev');
+        $this->dropColumn(Table::PARTNERS, 'isCraftVerified');
+        $this->dropColumn(Table::PARTNERS, 'isCommerceVerified');
+        $this->dropColumn(Table::PARTNERS, 'isEnterpriseVerified');
 
         return true;
     }

--- a/migrations/m181019_015807_add_column_isregisteredbusiness.php
+++ b/migrations/m181019_015807_add_column_isregisteredbusiness.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181019_015807_add_column_isregisteredbusiness migration.
@@ -15,7 +16,7 @@ class m181019_015807_add_column_isregisteredbusiness extends Migration
     public function safeUp()
     {
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'isRegisteredBusiness',
             $this->boolean()->defaultValue(false)->after('isEnterpriseVerified')
         );
@@ -26,7 +27,7 @@ class m181019_015807_add_column_isregisteredbusiness extends Migration
      */
     public function safeDown()
     {
-        $this->dropcolumn('craftnet_partners', 'isRegisteredBusiness');
+        $this->dropcolumn(Table::PARTNERS, 'isRegisteredBusiness');
 
         return true;
     }

--- a/migrations/m181019_024758_add_column_agencysize.php
+++ b/migrations/m181019_024758_add_column_agencysize.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181019_024758_add_column_agencysize migration.
@@ -15,7 +16,7 @@ class m181019_024758_add_column_agencysize extends Migration
     public function safeUp()
     {
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'agencySize',
             $this->integer()->after('isRegisteredBusiness')
         );
@@ -26,7 +27,7 @@ class m181019_024758_add_column_agencysize extends Migration
      */
     public function safeDown()
     {
-        $this->dropcolumn('craftnet_partners', 'agencySize');
+        $this->dropcolumn(Table::PARTNERS, 'agencySize');
 
         return true;
     }

--- a/migrations/m181019_210735_drop_column_minimumbudget.php
+++ b/migrations/m181019_210735_drop_column_minimumbudget.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181019_210735_drop_column_minimumbudget migration.
@@ -14,7 +15,7 @@ class m181019_210735_drop_column_minimumbudget extends Migration
      */
     public function safeUp()
     {
-        $this->dropColumn('craftnet_partners', 'minimumBudget');
+        $this->dropColumn(Table::PARTNERS, 'minimumBudget');
     }
 
     /**
@@ -22,7 +23,7 @@ class m181019_210735_drop_column_minimumbudget extends Migration
      */
     public function safeDown()
     {
-        $this->addColumn('craftnet_partners', 'minimumBudget', $this->integer());
+        $this->addColumn(Table::PARTNERS, 'minimumBudget', $this->integer());
 
         return true;
     }

--- a/migrations/m181019_211606_partner_bio_columns.php
+++ b/migrations/m181019_211606_partner_bio_columns.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181019_211606_partner_bio_columns migration.
@@ -15,12 +16,12 @@ class m181019_211606_partner_bio_columns extends Migration
     public function safeUp()
     {
         $this->addColumn(
-            'craftnet_partners',
+            Table::PARTNERS,
             'shortBio',
             $this->string()->after('businessSummary')
         );
 
-        $this->renameColumn('craftnet_partners', 'businessSummary', 'fullBio');
+        $this->renameColumn(Table::PARTNERS, 'businessSummary', 'fullBio');
     }
 
     /**
@@ -28,8 +29,8 @@ class m181019_211606_partner_bio_columns extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partners', 'shortBio');
-        $this->renameColumn('craftnet_partners', 'fullBio', 'businessSummary');
+        $this->dropColumn(Table::PARTNERS, 'shortBio');
+        $this->renameColumn(Table::PARTNERS, 'fullBio', 'businessSummary');
 
         return true;
     }

--- a/migrations/m181019_214421_partner_project_columns.php
+++ b/migrations/m181019_214421_partner_project_columns.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181019_214421_partner_project_columns migration.
@@ -14,9 +15,9 @@ class m181019_214421_partner_project_columns extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partnerprojects', 'name', $this->string()->after('partnerId'));
-        $this->addColumn('craftnet_partnerprojects', 'role', $this->string()->after('name'));
-        $this->dropColumn('craftnet_partnerprojects', 'private');
+        $this->addColumn(Table::PARTNERPROJECTS, 'name', $this->string()->after('partnerId'));
+        $this->addColumn(Table::PARTNERPROJECTS, 'role', $this->string()->after('name'));
+        $this->dropColumn(Table::PARTNERPROJECTS, 'private');
     }
 
     /**
@@ -24,9 +25,9 @@ class m181019_214421_partner_project_columns extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partnerprojects', 'name');
-        $this->dropColumn('craftnet_partnerprojects', 'role');
-        $this->addColumn('craftnet_partnerprojects', 'private', $this->boolean()->after('url'));
+        $this->dropColumn(Table::PARTNERPROJECTS, 'name');
+        $this->dropColumn(Table::PARTNERPROJECTS, 'role');
+        $this->addColumn(Table::PARTNERPROJECTS, 'private', $this->boolean()->after('url'));
 
         return true;
     }

--- a/migrations/m181023_212855_add_column_partner_verification_date.php
+++ b/migrations/m181023_212855_add_column_partner_verification_date.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181023_212855_add_column_partner_verification_date migration.
@@ -14,7 +15,7 @@ class m181023_212855_add_column_partner_verification_date extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partners', 'verificationStartDate', $this->date());
+        $this->addColumn(Table::PARTNERS, 'verificationStartDate', $this->date());
     }
 
     /**
@@ -22,7 +23,7 @@ class m181023_212855_add_column_partner_verification_date extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partners', 'verificationStartDate');
+        $this->dropColumn(Table::PARTNERS, 'verificationStartDate');
 
         return true;
     }

--- a/migrations/m181024_164339_add_column_partnerregion.php
+++ b/migrations/m181024_164339_add_column_partnerregion.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181024_164339_add_column_partnerregion migration.
@@ -14,7 +15,7 @@ class m181024_164339_add_column_partnerregion extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partners', 'region', $this->string());
+        $this->addColumn(Table::PARTNERS, 'region', $this->string());
     }
 
     /**
@@ -22,7 +23,7 @@ class m181024_164339_add_column_partnerregion extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partners', 'region');
+        $this->dropColumn(Table::PARTNERS, 'region');
 
         return true;
     }

--- a/migrations/m181024_194533_add_column_partnerexpertise.php
+++ b/migrations/m181024_194533_add_column_partnerexpertise.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181024_194533_add_column_partnerexpertise migration.
@@ -14,7 +15,7 @@ class m181024_194533_add_column_partnerexpertise extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partners', 'expertise', $this->text());
+        $this->addColumn(Table::PARTNERS, 'expertise', $this->text());
     }
 
     /**
@@ -23,7 +24,7 @@ class m181024_194533_add_column_partnerexpertise extends Migration
     public function safeDown()
     {
 
-        $this->dropColumn('craftnet_partners', 'expertise');
+        $this->dropColumn(Table::PARTNERS, 'expertise');
 
         return true;
     }

--- a/migrations/m181024_213825_remove_partner_msa.php
+++ b/migrations/m181024_213825_remove_partner_msa.php
@@ -4,6 +4,7 @@ namespace craft\contentmigrations;
 
 use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181024_213825_remove_partner_msa migration.
@@ -15,7 +16,7 @@ class m181024_213825_remove_partner_msa extends Migration
      */
     public function safeUp()
     {
-        $this->dropColumn('craftnet_partners', 'msaAssetId');
+        $this->dropColumn(Table::PARTNERS, 'msaAssetId');
 
         $volumes = Craft::$app->getVolumes();
         $volume = $volumes->getVolumeByHandle('partnerDocuments');
@@ -30,7 +31,7 @@ class m181024_213825_remove_partner_msa extends Migration
      */
     public function safeDown()
     {
-        $this->addColumn('craftnet_partners', 'msaAssetId', $this->integer());
+        $this->addColumn(Table::PARTNERS, 'msaAssetId', $this->integer());
         return true;
     }
 }

--- a/migrations/m181024_215625_alter_partner_agencysize.php
+++ b/migrations/m181024_215625_alter_partner_agencysize.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181024_215625_alter_partner_agencysize migration.
@@ -14,7 +15,7 @@ class m181024_215625_alter_partner_agencysize extends Migration
      */
     public function safeUp()
     {
-        $this->alterColumn('craftnet_partners', 'agencySize', 'string');
+        $this->alterColumn(Table::PARTNERS, 'agencySize', 'string');
     }
 
     /**

--- a/migrations/m181105_203112_add_column_websiteslug.php
+++ b/migrations/m181105_203112_add_column_websiteslug.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181105_203112_add_column_websiteslug migration.
@@ -14,7 +15,7 @@ class m181105_203112_add_column_websiteslug extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partners', 'websiteSlug', $this->string());
+        $this->addColumn(Table::PARTNERS, 'websiteSlug', $this->string());
     }
 
     /**
@@ -22,7 +23,7 @@ class m181105_203112_add_column_websiteslug extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partners', 'websiteSlug');
+        $this->dropColumn(Table::PARTNERS, 'websiteSlug');
 
         return true;
     }

--- a/migrations/m181106_195542_add_column_logoassetid.php
+++ b/migrations/m181106_195542_add_column_logoassetid.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181106_195542_add_column_logoassetid migration.
@@ -14,7 +15,7 @@ class m181106_195542_add_column_logoassetid extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partners', 'logoAssetId', $this->integer());
+        $this->addColumn(Table::PARTNERS, 'logoAssetId', $this->integer());
     }
 
     /**
@@ -22,7 +23,7 @@ class m181106_195542_add_column_logoassetid extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partners', 'logoAssetId');
+        $this->dropColumn(Table::PARTNERS, 'logoAssetId');
 
         return false;
     }

--- a/migrations/m181108_155858_insert_partner_capability.php
+++ b/migrations/m181108_155858_insert_partner_capability.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181108_155858_insert_partner_capability migration.
@@ -14,7 +15,7 @@ class m181108_155858_insert_partner_capability extends Migration
      */
     public function safeUp()
     {
-        $this->insert('craftnet_partnercapabilities', [
+        $this->insert(Table::PARTNERCAPABILITIES, [
             'id' => 5,
             'title' => 'Ongoing Maintenance'
         ], false);
@@ -25,7 +26,7 @@ class m181108_155858_insert_partner_capability extends Migration
      */
     public function safeDown()
     {
-        $this->delete('craftnet_partnercapabilities', ['id' => 5]);
+        $this->delete(Table::PARTNERCAPABILITIES, ['id' => 5]);
         return true;
     }
 }

--- a/migrations/m181108_180436_add_column_partner_website.php
+++ b/migrations/m181108_180436_add_column_partner_website.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181108_180436_add_column_partner_website migration.
@@ -14,7 +15,7 @@ class m181108_180436_add_column_partner_website extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partners', 'website', $this->text());
+        $this->addColumn(Table::PARTNERS, 'website', $this->text());
     }
 
     /**
@@ -23,7 +24,7 @@ class m181108_180436_add_column_partner_website extends Migration
     public function safeDown()
     {
 
-        $this->dropColumn('craftnet_partners', 'website');
+        $this->dropColumn(Table::PARTNERS, 'website');
 
         return true;
     }

--- a/migrations/m181115_204831_add_column_partnerproject_linktype.php
+++ b/migrations/m181115_204831_add_column_partnerproject_linktype.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181115_204831_add_column_partnerproject_linktype migration.
@@ -14,7 +15,7 @@ class m181115_204831_add_column_partnerproject_linktype extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partnerprojects', 'linkType', $this->text()->defaultValue('website'));
+        $this->addColumn(Table::PARTNERPROJECTS, 'linkType', $this->text()->defaultValue('website'));
     }
 
     /**
@@ -22,7 +23,7 @@ class m181115_204831_add_column_partnerproject_linktype extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partnerprojects', 'linkType');
+        $this->dropColumn(Table::PARTNERPROJECTS, 'linkType');
 
         return true;
     }

--- a/migrations/m181116_194917_add_column_crafnetpartnerprojects_withcraftcommerce.php
+++ b/migrations/m181116_194917_add_column_crafnetpartnerprojects_withcraftcommerce.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181116_194917_add_column_crafnetpartnerprojects_withcraftcommerce migration.
@@ -15,7 +16,7 @@ class m181116_194917_add_column_crafnetpartnerprojects_withcraftcommerce extends
     public function safeUp()
     {
         $this->addColumn(
-            'craftnet_partnerprojects',
+            Table::PARTNERPROJECTS,
             'withCraftCommerce',
             $this->boolean()->defaultValue(false)->notNull()
         );
@@ -26,7 +27,7 @@ class m181116_194917_add_column_crafnetpartnerprojects_withcraftcommerce extends
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_partnerprojects', 'withCraftCommerce');
+        $this->dropColumn(Table::PARTNERPROJECTS, 'withCraftCommerce');
 
         return true;
     }

--- a/migrations/m181123_183643_plugin_editions.php
+++ b/migrations/m181123_183643_plugin_editions.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m181123_183643_plugin_editions migration.
@@ -15,7 +16,7 @@ class m181123_183643_plugin_editions extends Migration
     public function safeUp()
     {
         // Add the features column
-        $this->addColumn('craftnet_plugineditions', 'features', $this->text());
+        $this->addColumn(Table::PLUGINEDITIONS, 'features', $this->text());
 
         // Update renewal prices
         // (due to a bug these were always getting set to the main price)
@@ -32,8 +33,8 @@ SQL;
         $this->execute($sql);
 
         // Delete the price columns from the main plugin table
-        $this->dropColumn('craftnet_plugins', 'price');
-        $this->dropColumn('craftnet_plugins', 'renewalPrice');
+        $this->dropColumn(Table::PLUGINS, 'price');
+        $this->dropColumn(Table::PLUGINS, 'renewalPrice');
     }
 
     /**

--- a/migrations/m181218_202516_package_developers.php
+++ b/migrations/m181218_202516_package_developers.php
@@ -3,6 +3,8 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
 
 /**
  * m181218_202516_package_developers migration.
@@ -14,8 +16,8 @@ class m181218_202516_package_developers extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_packages', 'developerId', $this->integer());
-        $this->addForeignKey(null, 'craftnet_packages', ['developerId'], 'users', ['id'], 'SET NULL');
+        $this->addColumn(Table::PACKAGES, 'developerId', $this->integer());
+        $this->addForeignKey(null, Table::PACKAGES, ['developerId'], CraftTable::USERS, ['id'], 'SET NULL');
 
         // Populate the new developerId column with plugins' developerId's
         $sql = <<<SQL

--- a/migrations/m190228_095858_license_renewals.php
+++ b/migrations/m190228_095858_license_renewals.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m190228_095858_license_renewals migration.
@@ -14,16 +15,16 @@ class m190228_095858_license_renewals extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_cmslicenses', 'reminded', $this->boolean()->defaultValue(false)->notNull());
-        $this->addColumn('craftnet_pluginlicenses', 'reminded', $this->boolean()->defaultValue(false)->notNull());
+        $this->addColumn(Table::CMSLICENSES, 'reminded', $this->boolean()->defaultValue(false)->notNull());
+        $this->addColumn(Table::PLUGINLICENSES, 'reminded', $this->boolean()->defaultValue(false)->notNull());
 
-        $this->addColumn('craftnet_cmslicenses', 'renewalPrice', $this->decimal(14, 4)->unsigned()->null());
-        $this->addColumn('craftnet_pluginlicenses', 'renewalPrice', $this->decimal(14, 4)->unsigned()->null());
+        $this->addColumn(Table::CMSLICENSES, 'renewalPrice', $this->decimal(14, 4)->unsigned()->null());
+        $this->addColumn(Table::PLUGINLICENSES, 'renewalPrice', $this->decimal(14, 4)->unsigned()->null());
 
-        $this->createIndex(null, 'craftnet_cmslicenses', ['expirable', 'reminded', 'expiresOn']);
-        $this->createIndex(null, 'craftnet_pluginlicenses', ['expirable', 'reminded', 'expiresOn']);
+        $this->createIndex(null, Table::CMSLICENSES, ['expirable', 'reminded', 'expiresOn']);
+        $this->createIndex(null, Table::PLUGINLICENSES, ['expirable', 'reminded', 'expiresOn']);
 
-        $this->update('craftnet_cmslicenses', ['renewalPrice' => 59], [
+        $this->update(Table::CMSLICENSES, ['renewalPrice' => 59], [
             'editionId' => 1259,
             'expirable' => true
         ]);

--- a/migrations/m190612_121546_published_plugins.php
+++ b/migrations/m190612_121546_published_plugins.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m190612_121546_published_plugins migration.
@@ -14,7 +15,7 @@ class m190612_121546_published_plugins extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_plugins', 'published', $this->boolean()->defaultValue(false)->notNull());
+        $this->addColumn(Table::PLUGINS, 'published', $this->boolean()->defaultValue(false)->notNull());
         $sql = <<<SQL
 update craftnet_plugins p
 SET published = true

--- a/migrations/m200318_164019_add_sort_order_to_partner_projects.php
+++ b/migrations/m200318_164019_add_sort_order_to_partner_projects.php
@@ -4,6 +4,7 @@ namespace craft\contentmigrations;
 
 use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m200318_164019_add_sort_order_to_partner_projects migration.
@@ -15,7 +16,7 @@ class m200318_164019_add_sort_order_to_partner_projects extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_partnerprojects', 'sortOrder', $this->smallInteger()->unsigned()->notNull()->defaultValue(0));
+        $this->addColumn(Table::PARTNERPROJECTS, 'sortOrder', $this->smallInteger()->unsigned()->notNull()->defaultValue(0));
     }
 
     /**

--- a/migrations/m200609_230952_cmslicense_plugins.php
+++ b/migrations/m200609_230952_cmslicense_plugins.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m200609_230952_cmslicense_plugins migration.
@@ -14,15 +15,15 @@ class m200609_230952_cmslicense_plugins extends Migration
      */
     public function safeUp()
     {
-        $this->createTable('craftnet_cmslicense_plugins', [
+        $this->createTable(Table::CMSLICENSE_PLUGINS, [
             'licenseId' => $this->integer()->notNull(),
             'pluginId' => $this->integer()->notNull(),
             'timestamp' => $this->dateTime()->notNull(),
             'PRIMARY KEY([[licenseId]], [[pluginId]])',
         ]);
-        $this->createIndex(null, 'craftnet_cmslicense_plugins', ['pluginId', 'timestamp']);
-        $this->addForeignKey(null, 'craftnet_cmslicense_plugins', ['licenseId'], 'craftnet_cmslicenses', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_cmslicense_plugins', ['pluginId'], 'craftnet_plugins', ['id'], 'CASCADE');
+        $this->createIndex(null, Table::CMSLICENSE_PLUGINS, ['pluginId', 'timestamp']);
+        $this->addForeignKey(null, Table::CMSLICENSE_PLUGINS, ['licenseId'], Table::CMSLICENSES, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::CMSLICENSE_PLUGINS, ['pluginId'], Table::PLUGINS, ['id'], 'CASCADE');
     }
 
     /**

--- a/migrations/m200610_222854_drop_installedplugins_table.php
+++ b/migrations/m200610_222854_drop_installedplugins_table.php
@@ -2,8 +2,8 @@
 
 namespace craft\contentmigrations;
 
-use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m200610_222854_drop_installedplugins_table migration.
@@ -15,7 +15,7 @@ class m200610_222854_drop_installedplugins_table extends Migration
      */
     public function safeUp()
     {
-        $this->dropTable('craftnet_installedplugins');
+        $this->dropTable(Table::INSTALLEDPLUGINS);
     }
 
     /**

--- a/migrations/m200703_222854_add_license_status.php
+++ b/migrations/m200703_222854_add_license_status.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m200703_222854_add_license_status migration.
@@ -14,12 +15,12 @@ class m200703_222854_add_license_status extends Migration
      */
     public function safeUp()
     {
-        if (!$this->db->columnExists('{{%craftnet_cmslicenses}}', 'lastStatus')) {
-            $this->addColumn('{{%craftnet_cmslicenses}}', 'lastStatus', $this->string());
+        if (!$this->db->columnExists(Table::CMSLICENSES, 'lastStatus')) {
+            $this->addColumn(Table::CMSLICENSES, 'lastStatus', $this->string());
         }
 
-        if (!$this->db->columnExists('{{%craftnet_pluginlicenses}}', 'lastStatus')) {
-            $this->addColumn('{{%craftnet_pluginlicenses}}', 'lastStatus', $this->string());
+        if (!$this->db->columnExists(Table::PLUGINLICENSES, 'lastStatus')) {
+            $this->addColumn(Table::PLUGINLICENSES, 'lastStatus', $this->string());
         }
     }
 

--- a/migrations/m201120_235906_nullable_plugin_license_edition.php
+++ b/migrations/m201120_235906_nullable_plugin_license_edition.php
@@ -3,6 +3,7 @@
 namespace craft\contentmigrations;
 
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m201120_235906_nullable_plugin_license_edition migration.
@@ -16,7 +17,7 @@ class m201120_235906_nullable_plugin_license_edition extends Migration
     {
         $this->execute('alter table craftnet_pluginlicenses alter column "editionId" drop not null');
         $this->execute('alter table craftnet_pluginlicenses alter column "edition" drop not null');
-        $this->addColumn('craftnet_pluginlicenses', 'trial', $this->boolean()->notNull()->defaultValue(false));
+        $this->addColumn(Table::PLUGINLICENSES, 'trial', $this->boolean()->notNull()->defaultValue(false));
     }
 
     /**

--- a/migrations/m201216_172456_release_changelog_info.php
+++ b/migrations/m201216_172456_release_changelog_info.php
@@ -4,6 +4,7 @@ namespace craft\contentmigrations;
 
 use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m201216_172456_release_changelog_info migration.
@@ -15,9 +16,9 @@ class m201216_172456_release_changelog_info extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_packageversions', 'date', $this->dateTime());
-        $this->addColumn('craftnet_packageversions', 'critical', $this->boolean()->notNull()->defaultValue(false));
-        $this->addColumn('craftnet_packageversions', 'notes', $this->text());
+        $this->addColumn(Table::PACKAGEVERSIONS, 'date', $this->dateTime());
+        $this->addColumn(Table::PACKAGEVERSIONS, 'critical', $this->boolean()->notNull()->defaultValue(false));
+        $this->addColumn(Table::PACKAGEVERSIONS, 'notes', $this->text());
     }
 
     /**
@@ -25,8 +26,8 @@ class m201216_172456_release_changelog_info extends Migration
      */
     public function safeDown()
     {
-        $this->dropColumn('craftnet_packageversions', 'date');
-        $this->dropColumn('craftnet_packageversions', 'critical');
-        $this->dropColumn('craftnet_packageversions', 'notes');
+        $this->dropColumn(Table::PACKAGEVERSIONS, 'date');
+        $this->dropColumn(Table::PACKAGEVERSIONS, 'critical');
+        $this->dropColumn(Table::PACKAGEVERSIONS, 'notes');
     }
 }

--- a/migrations/m210218_234728_abandoned_plugins.php
+++ b/migrations/m210218_234728_abandoned_plugins.php
@@ -4,6 +4,7 @@ namespace craft\contentmigrations;
 
 use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
 
 /**
  * m210218_234728_abandoned_plugins migration.
@@ -15,9 +16,9 @@ class m210218_234728_abandoned_plugins extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn('craftnet_plugins', 'abandoned', $this->boolean()->notNull()->defaultValue(false));
-        $this->addColumn('craftnet_plugins', 'replacementId', $this->integer());
-        $this->addForeignKey(null, 'craftnet_plugins', ['replacementId'], 'craftnet_plugins', ['id'], 'SET NULL');
+        $this->addColumn(Table::PLUGINS, 'abandoned', $this->boolean()->notNull()->defaultValue(false));
+        $this->addColumn(Table::PLUGINS, 'replacementId', $this->integer());
+        $this->addForeignKey(null, Table::PLUGINS, ['replacementId'], Table::PLUGINS, ['id'], 'SET NULL');
     }
 
     /**

--- a/migrations/m210305_200103_payouts.php
+++ b/migrations/m210305_200103_payouts.php
@@ -2,8 +2,9 @@
 
 namespace craft\contentmigrations;
 
-use Craft;
 use craft\db\Migration;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
 
 /**
  * m210305_200103_payouts migration.
@@ -15,7 +16,7 @@ class m210305_200103_payouts extends Migration
      */
     public function safeUp()
     {
-        $this->createTable('craftnet_payouts', [
+        $this->createTable(Table::PAYOUTS, [
             'id' => $this->primaryKey(),
             'payoutBatchId' => $this->string(),
             'status' => $this->string(),
@@ -23,9 +24,9 @@ class m210305_200103_payouts extends Migration
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
         ]);
-        $this->createIndex(null, 'craftnet_payouts', ['status']);
+        $this->createIndex(null, Table::PAYOUTS, ['status']);
 
-        $this->createTable('craftnet_payout_items', [
+        $this->createTable(Table::PAYOUT_ITEMS, [
             'id' => $this->primaryKey(),
             'payoutId' => $this->integer()->notNull(),
             'developerId' => $this->integer()->notNull(),
@@ -38,17 +39,17 @@ class m210305_200103_payouts extends Migration
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
         ]);
-        $this->addForeignKey(null, 'craftnet_payout_items', ['payoutId'], 'craftnet_payouts', ['id'], 'CASCADE');
-        $this->addForeignKey(null, 'craftnet_payout_items', ['developerId'], 'users', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PAYOUT_ITEMS, ['payoutId'], Table::PAYOUT_ITEMS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PAYOUT_ITEMS, ['developerId'], CraftTable::USERS, ['id'], 'CASCADE');
 
-        $this->createTable('craftnet_payout_errors', [
+        $this->createTable(Table::PAYOUT_ERRORS, [
             'id' => $this->primaryKey(),
             'payoutId' => $this->integer()->notNull(),
             'message' => $this->text()->notNull(),
             'data' => $this->text(),
             'date' => $this->dateTime()->notNull(),
         ]);
-        $this->addForeignKey(null, 'craftnet_payout_errors', ['payoutId'], 'craftnet_payouts', ['id'], 'CASCADE');
+        $this->addForeignKey(null, Table::PAYOUT_ERRORS, ['payoutId'], Table::PAYOUTS, ['id'], 'CASCADE');
     }
 
     /**
@@ -56,8 +57,8 @@ class m210305_200103_payouts extends Migration
      */
     public function safeDown()
     {
-        $this->dropTable('craftnet_payout_errors');
-        $this->dropTable('craftnet_payout_items');
-        $this->dropTable('craftnet_payouts');
+        $this->dropTable(Table::PAYOUT_ERRORS);
+        $this->dropTable(Table::PAYOUT_ITEMS);
+        $this->dropTable(Table::PAYOUTS);
     }
 }

--- a/migrations/m210330_200103_index_pl_datecreated.php
+++ b/migrations/m210330_200103_index_pl_datecreated.php
@@ -4,6 +4,7 @@ namespace craft\contentmigrations;
 
 use craft\db\Migration;
 use craft\helpers\MigrationHelper;
+use craftnet\db\Table;
 
 /**
  * m210330_200103_index_pl_datecreated migration.
@@ -15,8 +16,8 @@ class m210330_200103_index_pl_datecreated extends Migration
      */
     public function safeUp()
     {
-        if (!MigrationHelper::doesIndexExist('craftnet_pluginlicenses', ['dateCreated'])) {
-            $this->createIndex(null, 'craftnet_pluginlicenses', ['dateCreated']);
+        if (!MigrationHelper::doesIndexExist(Table::PLUGINLICENSES, ['dateCreated'])) {
+            $this->createIndex(null, Table::PLUGINLICENSES, ['dateCreated']);
         }
     }
 
@@ -25,8 +26,8 @@ class m210330_200103_index_pl_datecreated extends Migration
      */
     public function safeDown()
     {
-        if (MigrationHelper::doesIndexExist('craftnet_pluginlicenses', ['dateCreated'])) {
-            $this->dropIndex($this->db->getIndexName('craftnet_pluginlicenses', ['dateCreated']), 'craftnet_pluginlicenses');
+        if (MigrationHelper::doesIndexExist(Table::PLUGINLICENSES, ['dateCreated'])) {
+            $this->dropIndex($this->db->getIndexName(Table::PLUGINLICENSES, ['dateCreated']), Table::PLUGINLICENSES);
         }
     }
 }

--- a/src/behaviors/UserBehavior.php
+++ b/src/behaviors/UserBehavior.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\base\Element;
 use craft\elements\User;
 use craft\events\DefineRulesEvent;
+use craftnet\db\Table;
 use craftnet\developers\EmailVerifier;
 use craftnet\developers\FundsManager;
 use craftnet\helpers\KeyHelper;
@@ -213,7 +214,7 @@ class UserBehavior extends Behavior
     public function saveDeveloperInfo()
     {
         Craft::$app->getDb()->createCommand()
-            ->upsert('craftnet_developers', [
+            ->upsert(Table::DEVELOPERS, [
                 'id' => $this->owner->id,
             ], [
                 'country' => $this->country,

--- a/src/behaviors/UserQueryBehavior.php
+++ b/src/behaviors/UserQueryBehavior.php
@@ -4,6 +4,7 @@ namespace craftnet\behaviors;
 
 use craft\elements\db\ElementQuery;
 use craft\elements\db\UserQuery;
+use craftnet\db\Table;
 use yii\base\Behavior;
 
 /**
@@ -38,7 +39,7 @@ class UserQueryBehavior extends Behavior
             'developers.apiToken',
         ]);
 
-        $this->owner->query->leftJoin('craftnet_developers developers', '[[developers.id]] = [[users.id]]');
-        $this->owner->subQuery->leftJoin('craftnet_developers developers', '[[developers.id]] = [[users.id]]');
+        $this->owner->query->leftJoin(Table::DEVELOPERS . ' developers', '[[developers.id]] = [[users.id]]');
+        $this->owner->subQuery->leftJoin(Table::DEVELOPERS . ' developers', '[[developers.id]] = [[users.id]]');
     }
 }

--- a/src/cms/CmsEdition.php
+++ b/src/cms/CmsEdition.php
@@ -9,6 +9,7 @@ use craft\commerce\Plugin as Commerce;
 use craft\elements\db\ElementQueryInterface;
 use craftnet\base\EditionInterface;
 use craftnet\base\RenewalInterface;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\helpers\OrderHelper;
 use craftnet\Module;
@@ -148,11 +149,11 @@ class CmsEdition extends CmsPurchasable implements EditionInterface
 
         if ($isNew) {
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_cmseditions', $data, false)
+                ->insert(Table::CMSEDITIONS, $data, false)
                 ->execute();
         } else {
             Craft::$app->getDb()->createCommand()
-                ->update('craftnet_cmseditions', $data, ['id' => $this->id], [], false)
+                ->update(Table::CMSEDITIONS, $data, ['id' => $this->id], [], false)
                 ->execute();
         }
 
@@ -292,7 +293,7 @@ class CmsEdition extends CmsPurchasable implements EditionInterface
 
             // relate the license to the line item
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_cmslicenses_lineitems', [
+                ->insert(Table::CMSLICENSES_LINEITEMS, [
                     'licenseId' => $license->id,
                     'lineItemId' => $lineItem->id,
                 ], false)

--- a/src/cms/CmsEditionQuery.php
+++ b/src/cms/CmsEditionQuery.php
@@ -4,6 +4,7 @@ namespace craftnet\cms;
 
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
+use craftnet\db\Table;
 use yii\db\Connection;
 
 /**
@@ -46,14 +47,14 @@ class CmsEditionQuery extends ElementQuery
         $this->joinElementTable('craftnet_cmseditions');
 
         $this->query->select([
-            'craftnet_cmseditions.name',
-            'craftnet_cmseditions.handle',
-            'craftnet_cmseditions.price',
-            'craftnet_cmseditions.renewalPrice',
+            Table::CMSEDITIONS . '.name',
+            Table::CMSEDITIONS . '.handle',
+            Table::CMSEDITIONS . '.price',
+            Table::CMSEDITIONS . '.renewalPrice',
         ]);
 
         if ($this->handle) {
-            $this->subQuery->andWhere(Db::parseParam('craftnet_cmseditions.handle', $this->handle));
+            $this->subQuery->andWhere(Db::parseParam(Table::CMSEDITIONS . '.handle', $this->handle));
         }
 
         return parent::beforePrepare();

--- a/src/cms/CmsRenewal.php
+++ b/src/cms/CmsRenewal.php
@@ -7,6 +7,7 @@ use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
 use craft\elements\db\ElementQueryInterface;
 use craftnet\base\RenewalInterface;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\helpers\OrderHelper;
 use craftnet\Module;
@@ -18,9 +19,6 @@ use yii\base\InvalidConfigException;
  */
 class CmsRenewal extends CmsPurchasable implements RenewalInterface
 {
-    // Static
-    // =========================================================================
-
     /**
      * @return string
      */
@@ -37,9 +35,6 @@ class CmsRenewal extends CmsPurchasable implements RenewalInterface
         return new CmsRenewalQuery(static::class);
     }
 
-    // Properties
-    // =========================================================================
-
     /**
      * @var int The CMS edition ID
      */
@@ -49,9 +44,6 @@ class CmsRenewal extends CmsPurchasable implements RenewalInterface
      * @var float The renewal price
      */
     public $price;
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @inheritdoc
@@ -86,11 +78,11 @@ class CmsRenewal extends CmsPurchasable implements RenewalInterface
 
         if ($isNew) {
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_cmsrenewals', $data, false)
+                ->insert(Table::CMSRENEWALS, $data, false)
                 ->execute();
         } else {
             Craft::$app->getDb()->createCommand()
-                ->update('craftnet_cmsrenewals', $data, ['id' => $this->id], [], false)
+                ->update(Table::CMSRENEWALS, $data, ['id' => $this->id], [], false)
                 ->execute();
         }
 
@@ -163,9 +155,6 @@ class CmsRenewal extends CmsPurchasable implements RenewalInterface
         parent::afterOrderComplete($order, $lineItem);
     }
 
-    // Private Methods
-    // =========================================================================
-
     /**
      * @param Order $order
      * @param LineItem $lineItem
@@ -197,7 +186,7 @@ class CmsRenewal extends CmsPurchasable implements RenewalInterface
 
             // relate the license to the line item
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_cmslicenses_lineitems', [
+                ->insert(Table::CMSLICENSES_LINEITEMS, [
                     'licenseId' => $license->id,
                     'lineItemId' => $lineItem->id,
                 ], false)

--- a/src/cms/CmsRenewalQuery.php
+++ b/src/cms/CmsRenewalQuery.php
@@ -4,6 +4,7 @@ namespace craftnet\cms;
 
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
+use craftnet\db\Table;
 use yii\db\Connection;
 
 /**
@@ -36,12 +37,12 @@ class CmsRenewalQuery extends ElementQuery
         $this->joinElementTable('craftnet_cmsrenewals');
 
         $this->query->select([
-            'craftnet_cmsrenewals.editionId',
-            'craftnet_cmsrenewals.price',
+            Table::CMSRENEWALS . '.editionId',
+            Table::CMSRENEWALS . '.price',
         ]);
 
         if ($this->editionId) {
-            $this->subQuery->andWhere(Db::parseParam('craftnet_cmsrenewals.editionId', $this->editionId));
+            $this->subQuery->andWhere(Db::parseParam(Table::CMSRENEWALS . '.editionId', $this->editionId));
         }
 
         return parent::beforePrepare();

--- a/src/composer/JsonDumper.php
+++ b/src/composer/JsonDumper.php
@@ -17,6 +17,7 @@ use craft\helpers\FileHelper;
 use craft\helpers\Json;
 use craftnet\composer\jobs\DeletePaths;
 use craftnet\composer\jobs\DumpJson;
+use craftnet\db\Table;
 use craftnet\Module;
 use yii\base\Component;
 
@@ -74,7 +75,7 @@ class JsonDumper extends Component
         // Fetch all the data
         $packages = (new Query())
             ->select(['id', 'name', 'abandoned', 'replacementPackage'])
-            ->from(['craftnet_packages'])
+            ->from([Table::PACKAGES])
             ->indexBy('id')
             ->all();
 
@@ -104,7 +105,7 @@ class JsonDumper extends Component
                 //'source',
                 'dist',
             ])
-            ->from(['craftnet_packageversions'])
+            ->from([Table::PACKAGEVERSIONS])
             ->where([
                 'packageId' => array_keys($packages),
                 'valid' => true,
@@ -117,7 +118,7 @@ class JsonDumper extends Component
 
         $deps = (new Query())
             ->select(['versionId', 'name', 'constraints'])
-            ->from(['craftnet_packagedeps'])
+            ->from([Table::PACKAGEDEPS])
             ->all();
 
         if ($isConsole) {

--- a/src/console/controllers/AccountsController.php
+++ b/src/console/controllers/AccountsController.php
@@ -13,6 +13,8 @@ use craftnet\plugins\Plugin;
 use yii\console\Controller;
 use yii\console\ExitCode;
 use yii\helpers\Console;
+use craftnet\db\Table;
+use craft\commerce\db\Table as CommerceTable;
 
 /**
  * Show information about accounts
@@ -95,21 +97,21 @@ class AccountsController extends Controller
         $db = Craft::$app->getDb();
 
         $customerTables = [
-            'commerce_customer_discountuses',
-            'commerce_customers_addresses',
-            'commerce_orderhistories',
-            'commerce_orders',
+            CommerceTable::CUSTOMER_DISCOUNTUSES,
+            CommerceTable::CUSTOMERS_ADDRESSES,
+            CommerceTable::ORDERHISTORIES,
+            CommerceTable::ORDERS,
         ];
 
         $userTables = [
-            'commerce_paymentsources',
-            'commerce_subscriptions',
-            'commerce_transactions',
-            'craftnet_cmslicenses' => 'ownerId',
-            'craftnet_pluginlicenses' => 'ownerId',
-            'craftnet_plugins' => 'developerId',
-            'craftnet_developerledger' => 'developerId',
-            'craftnet_packages' => 'developerId',
+            CommerceTable::PAYMENTSOURCES,
+            CommerceTable::SUBSCRIPTIONS,
+            CommerceTable::TRANSACTIONS,
+            Table::CMSLICENSES => 'ownerId',
+            Table::PLUGINLICENSES => 'ownerId',
+            Table::PLUGINS => 'developerId',
+            Table::DEVELOPERLEDGER => 'developerId',
+            Table::PACKAGES => 'developerId',
         ];
 
         $customer1 = $commerce->getCustomers()->getCustomerByUserId($id1);
@@ -128,7 +130,7 @@ class AccountsController extends Controller
             $commerce->getCustomers()->deleteCustomer($customer1);
             $this->stdout('done' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
         } else if ($customer1) {
-            $userTables[] = 'commerce_customers';
+            $userTables[] = CommerceTable::CUSTOMERS;
         }
 
         foreach ($userTables as $table => $column) {

--- a/src/console/controllers/ClaimLicensesController.php
+++ b/src/console/controllers/ClaimLicensesController.php
@@ -7,6 +7,7 @@ use craft\commerce\Plugin as Commerce;
 use craft\elements\User;
 use craft\helpers\ArrayHelper;
 use craftnet\behaviors\UserBehavior;
+use craftnet\db\Table;
 use craftnet\Module;
 use yii\console\Controller;
 use yii\db\Query;
@@ -64,14 +65,14 @@ class ClaimLicensesController extends Controller
             ];
             $cmsLicenses = (new Query())
                 ->select(['email', 'count(*) as total'])
-                ->from(['craftnet_cmslicenses'])
+                ->from([Table::CMSLICENSES])
                 ->where($condition)
                 ->groupBy('email')
                 ->indexBy('email')
                 ->all();
             $pluginLicenses = (new Query())
                 ->select(['email', 'count(*) as total'])
-                ->from(['craftnet_pluginlicenses'])
+                ->from([Table::PLUGINLICENSES])
                 ->where($condition)
                 ->groupBy('email')
                 ->indexBy('email')

--- a/src/console/controllers/CmsLicensesController.php
+++ b/src/console/controllers/CmsLicensesController.php
@@ -8,6 +8,7 @@ use craft\elements\User;
 use craft\helpers\DateTimeHelper;
 use craftnet\behaviors\UserBehavior;
 use craftnet\cms\CmsLicense;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\helpers\KeyHelper;
 use craftnet\Module;
@@ -205,7 +206,7 @@ class CmsLicensesController extends Controller
         } catch (InvalidArgumentException $e) {
             $licenses = (new Query())
                 ->select(['key', 'domain'])
-                ->from(['craftnet_cmslicenses'])
+                ->from([Table::CMSLICENSES])
                 ->where(['like', 'key', $key . '%', false])
                 ->all();
 

--- a/src/console/controllers/ComposerCheckController.php
+++ b/src/console/controllers/ComposerCheckController.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\db\Query;
 use craft\helpers\FileHelper;
 use craft\helpers\Json;
+use craftnet\db\Table;
 use craftnet\Module;
 use craftnet\plugins\Plugin;
 use Symfony\Component\Process\Process;
@@ -171,7 +172,7 @@ class ComposerCheckController extends Controller
 
                 $package = (new Query())
                     ->select(['id', 'repository'])
-                    ->from('craftnet_packages')
+                    ->from(Table::PACKAGES)
                     ->where(['name' => $packageName])
                     ->one();
 

--- a/src/console/controllers/FixLicenseExpiryDatesController.php
+++ b/src/console/controllers/FixLicenseExpiryDatesController.php
@@ -9,6 +9,7 @@ use craft\helpers\DateTimeHelper;
 use craft\helpers\Json;
 use craftnet\base\LicenseInterface;
 use craftnet\cms\CmsLicense;
+use craftnet\db\Table;
 use craftnet\helpers\OrderHelper;
 use craftnet\Module;
 use yii\console\Controller;
@@ -97,12 +98,12 @@ SQL;
                     // See if we can determine the previous expiry date for this license
                     /** @var LicenseInterface $license */
                     if ($lineItem['cmsLicenseId']) {
-                        $joinTable = 'craftnet_cmslicenses_lineitems';
+                        $joinTable = Table::CMSLICENSES_LINEITEMS;
                         $licenseId = $lineItem['cmsLicenseId'];
                         $license = $cmsLicenseManager->getLicenseById($licenseId);
                         $itemName = 'Craft Pro';
                     } else {
-                        $joinTable = 'craftnet_pluginlicenses_lineitems';
+                        $joinTable = Table::PLUGINLICENSES_LINEITEMS;
                         $licenseId = $lineItem['pluginLicenseId'];
                         $license = $pluginLicenseManager->getLicenseById($licenseId);
                         $itemName = $license->getPlugin()->name;

--- a/src/console/controllers/FundsController.php
+++ b/src/console/controllers/FundsController.php
@@ -7,6 +7,7 @@ use craft\db\Query;
 use craft\elements\User;
 use craft\i18n\Locale;
 use craftnet\behaviors\UserBehavior;
+use craftnet\db\Table;
 use craftnet\Module;
 use yii\console\Controller;
 use yii\console\ExitCode;
@@ -164,7 +165,7 @@ class FundsController extends Controller
 
         $records = (new Query())
             ->select(['dateCreated', 'note', 'type', 'credit', 'debit', 'balance'])
-            ->from(['craftnet_developerledger'])
+            ->from([Table::DEVELOPERLEDGER])
             ->where(['developerId' => $account->id])
             ->orderBy(['id' => SORT_ASC])
             ->all();

--- a/src/console/controllers/MigrateInstalledPluginsController.php
+++ b/src/console/controllers/MigrateInstalledPluginsController.php
@@ -5,6 +5,7 @@ namespace craftnet\console\controllers;
 use Craft;
 use craft\db\Query;
 use craft\helpers\Console;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\Module;
 use yii\console\Controller;
@@ -25,7 +26,7 @@ class MigrateInstalledPluginsController extends Controller
 
         $query = (new Query())
             ->select(['craftLicenseKey', 'pluginId', 'lastActivity'])
-            ->from(['craftnet_installedplugins'])
+            ->from([Table::INSTALLEDPLUGINS])
             ->orderBy(['lastActivity' => SORT_ASC]);
 
         foreach ($query->each() as $row) {
@@ -54,7 +55,7 @@ class MigrateInstalledPluginsController extends Controller
                 $data[] = [$license->id, $pluginId, $timestamp];
             }
             $db->createCommand()
-                ->batchInsert('craftnet_cmslicense_plugins', ['licenseId', 'pluginId', 'timestamp'], $data, false)
+                ->batchInsert(Table::CMSLICENSE_PLUGINS, ['licenseId', 'pluginId', 'timestamp'], $data, false)
                 ->execute();
             $this->stdout('done' . PHP_EOL, Console::FG_GREEN);
         }

--- a/src/console/controllers/PluginLicensesController.php
+++ b/src/console/controllers/PluginLicensesController.php
@@ -10,6 +10,7 @@ use craft\db\Query;
 use craft\elements\User;
 use craft\helpers\ArrayHelper;
 use craft\helpers\DateTimeHelper;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\helpers\KeyHelper;
 use craftnet\Module;
@@ -126,7 +127,7 @@ class PluginLicensesController extends Controller
             $key = $this->select('Which line item?', $lineItemOptions);
             $lineItem = $lineItems[$key];
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_pluginlicenses_lineitems', [
+                ->insert(Table::PLUGINLICENSES_LINEITEMS, [
                     'licenseId' => $license->id,
                     'lineItemId' => $lineItem->id,
                 ], false)
@@ -196,7 +197,7 @@ class PluginLicensesController extends Controller
                 'ownerId' => 'old.ownerId',
                 'cmsLicenseId' => 'old.cmsLicenseId',
             ])
-            ->from('craftnet_pluginlicenses old')
+            ->from(Table::PLUGINLICENSES . ' old')
             ->where(['old.editionId' => $oldEdition->id]);
 
         if ($liteEdition->price != 0) {
@@ -204,7 +205,7 @@ class PluginLicensesController extends Controller
                 ->addSelect([
                     'liteId' => 'lite.id',
                 ])
-                ->leftJoin('craftnet_pluginlicenses lite', [
+                ->leftJoin(Table::PLUGINLICENSES . ' lite', [
                     'and',
                     ['lite.editionId' => $liteEdition->id],
                     '[[lite.cmsLicenseId]] = [[old.cmsLicenseId]]',

--- a/src/controllers/CmsLicensesController.php
+++ b/src/controllers/CmsLicensesController.php
@@ -9,6 +9,7 @@ use craft\elements\User;
 use craft\web\Controller;
 use craft\web\twig\variables\Paginate;
 use craftnet\cms\CmsLicense;
+use craftnet\db\Table;
 use yii\helpers\ArrayHelper;
 use yii\web\Response;
 
@@ -20,7 +21,7 @@ class CmsLicensesController extends Controller
     public function actionIndex(): Response
     {
         $query = (new Query())
-            ->from(['l' => 'craftnet_cmslicenses'])
+            ->from(['l' => Table::CMSLICENSES])
             ->orderBy(['dateCreated' => SORT_DESC]);
 
         if ($edition = $this->request->getQueryParam('edition', 'pro')) {

--- a/src/controllers/FrontController.php
+++ b/src/controllers/FrontController.php
@@ -19,6 +19,7 @@ use craft\helpers\Json;
 use craft\web\Controller;
 use craftnet\behaviors\UserBehavior;
 use craftnet\cms\CmsLicense;
+use craftnet\db\Table;
 use yii\db\Expression;
 use yii\web\BadRequestHttpException;
 use yii\web\Response;
@@ -155,7 +156,7 @@ class FrontController extends Controller
         }
 
         $results = (new Query())
-            ->from(['craftnet_cmslicenses'])
+            ->from([Table::CMSLICENSES])
             ->where($emailCondition)
             ->andWhere(['editionHandle' => 'pro'])
             ->orderBy(['dateCreated' => SORT_DESC])
@@ -187,7 +188,7 @@ class FrontController extends Controller
 
         $licenses = (new Query())
             ->select(['*'])
-            ->from('{{%craftnet_cmslicenses}}')
+            ->from(Table::CMSLICENSES)
             ->where([
                 'or',
                 ['key' => $key],

--- a/src/controllers/api/BaseApiController.php
+++ b/src/controllers/api/BaseApiController.php
@@ -15,6 +15,7 @@ use craft\web\Controller;
 use craftnet\behaviors\UserBehavior;
 use craftnet\cms\CmsLicense;
 use craftnet\cms\CmsLicenseManager;
+use craftnet\db\Table;
 use craftnet\errors\ExpiredTokenException;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\errors\ValidationException;
@@ -521,7 +522,7 @@ abstract class BaseApiController extends Controller
         if ($this->cmsVersion !== null && $cmsLicense !== null) {
             // delete any cmslicense_plugins rows for this license
             $db->createCommand()
-                ->delete('craftnet_cmslicense_plugins', [
+                ->delete(Table::CMSLICENSE_PLUGINS, [
                     'licenseId' => $cmsLicense->id,
                 ])
                 ->execute();
@@ -532,7 +533,7 @@ abstract class BaseApiController extends Controller
             }
             try {
                 $db->createCommand()
-                    ->batchInsert('craftnet_cmslicense_plugins', ['licenseId', 'pluginId', 'timestamp'], $licensePluginsData, false)
+                    ->batchInsert(Table::CMSLICENSE_PLUGINS, ['licenseId', 'pluginId', 'timestamp'], $licensePluginsData, false)
                     ->execute();
             } catch (\Throwable $exception) {
                 // don't let that ruin our day

--- a/src/controllers/api/v1/ComposerWhitelistController.php
+++ b/src/controllers/api/v1/ComposerWhitelistController.php
@@ -5,6 +5,7 @@ namespace craftnet\controllers\api\v1;
 use Composer\Semver\Comparator;
 use craft\db\Query;
 use craftnet\controllers\api\BaseApiController;
+use craftnet\db\Table;
 use craftnet\Module;
 use yii\web\BadRequestHttpException;
 use yii\web\Response;
@@ -102,7 +103,7 @@ class ComposerWhitelistController extends BaseApiController
             //->select(['pd.name', 'pd.constraints'])
             ->select(['pd.name'])
             ->distinct()
-            ->from(['craftnet_packagedeps pd'])
+            ->from([Table::PACKAGEDEPS . ' pd'])
             ->where([
                 'and',
                 ['not in', 'pd.name', array_keys($this->_ignoreDeps)],
@@ -137,7 +138,7 @@ class ComposerWhitelistController extends BaseApiController
 
         // Add their deps to the mix as well
         $deps = $this->_createDepQuery()
-            ->innerJoin('craftnet_packages p', '[[p.id]] = [[pd.packageId]]')
+            ->innerJoin(Table::PACKAGES . ' p', '[[p.id]] = [[pd.packageId]]')
             ->andWhere(['p.name' => $deps])
             ->column();
 

--- a/src/controllers/api/v1/OptimizeComposerReqsController.php
+++ b/src/controllers/api/v1/OptimizeComposerReqsController.php
@@ -5,6 +5,7 @@ namespace craftnet\controllers\api\v1;
 use Composer\Semver\Comparator;
 use craft\db\Query;
 use craftnet\controllers\api\BaseApiController;
+use craftnet\db\Table;
 use craftnet\Module;
 use yii\web\BadRequestHttpException;
 use yii\web\Response;
@@ -89,7 +90,7 @@ class OptimizeComposerReqsController extends BaseApiController
             //->select(['pd.name', 'pd.constraints'])
             ->select(['pd.name'])
             ->distinct()
-            ->from(['craftnet_packagedeps pd'])
+            ->from([Table::PACKAGEDEPS . ' pd'])
             ->where([
                 'and',
                 [
@@ -130,7 +131,7 @@ class OptimizeComposerReqsController extends BaseApiController
         // Get their package IDs
         $packageIds = (new Query())
             ->select(['id'])
-            ->from(['craftnet_packages'])
+            ->from([Table::PACKAGES])
             ->where(['name' => $deps])
             ->column();
 

--- a/src/controllers/api/v1/PluginsController.php
+++ b/src/controllers/api/v1/PluginsController.php
@@ -3,6 +3,7 @@
 namespace craftnet\controllers\api\v1;
 
 use craftnet\controllers\api\BaseApiController;
+use craftnet\db\Table;
 use craftnet\plugins\Plugin;
 use yii\web\Response;
 
@@ -11,9 +12,6 @@ use yii\web\Response;
  */
 class PluginsController extends BaseApiController
 {
-    // Public Methods
-    // =========================================================================
-
     /**
      * Handles /v1/plugins requests.
      *
@@ -29,7 +27,7 @@ class PluginsController extends BaseApiController
         $ids = explode(',', $ids);
 
         if ($ids) {
-            $pluginQuery->andWhere(['craftnet_plugins.id' => $ids]);
+            $pluginQuery->andWhere([Table::PLUGINS . '.id' => $ids]);
         }
 
         $plugins = $pluginQuery->all();
@@ -38,9 +36,6 @@ class PluginsController extends BaseApiController
 
         return $this->asJson($data);
     }
-
-    // Private Methods
-    // =========================================================================
 
     /**
      * @return \craft\elements\db\ElementQueryInterface|\craftnet\plugins\PluginQuery

--- a/src/controllers/api/v1/UpdatesController.php
+++ b/src/controllers/api/v1/UpdatesController.php
@@ -9,6 +9,7 @@ use craft\helpers\ArrayHelper;
 use craft\models\Update;
 use craftnet\composer\PackageRelease;
 use craftnet\controllers\api\BaseApiController;
+use craftnet\db\Table;
 use craftnet\errors\ValidationException;
 use craftnet\plugins\Plugin;
 use yii\web\BadRequestHttpException;
@@ -145,7 +146,7 @@ class UpdatesController extends BaseApiController
         if ($latest !== null && version_compare($this->cmsVersion, '3.5.15', '>=')) {
             $info['phpConstraint'] = (new Query())
                 ->select(['constraints'])
-                ->from(['craftnet_packagedeps'])
+                ->from([Table::PACKAGEDEPS])
                 ->where(['versionId' => $latest->id, 'name' => 'php'])
                 ->scalar() ?: null;
         }

--- a/src/controllers/feeds/FeedsController.php
+++ b/src/controllers/feeds/FeedsController.php
@@ -8,6 +8,8 @@ use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\UrlHelper;
 use craft\web\Controller;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
 use craftnet\Module;
 use craftnet\plugins\Plugin;
 use DateTime;
@@ -41,8 +43,8 @@ class FeedsController extends Controller
             ->withLatestReleaseInfo()
             ->with(['developer'])
             ->limit(20)
-            ->andWhere(['not', ['craftnet_plugins.dateApproved' => null]])
-            ->orderBy(['craftnet_plugins.dateApproved' => SORT_DESC])
+            ->andWhere(['not', [Table::PLUGINS . '.dateApproved' => null]])
+            ->orderBy([Table::PLUGINS . '.dateApproved' => SORT_DESC])
             ->all();
 
         return $this->_asFeed('New Plugins', array_map(function(Plugin $plugin): array {
@@ -112,9 +114,9 @@ class FeedsController extends Controller
                 'u.lastName',
                 'u.username',
             ])
-            ->innerJoin('craftnet_plugins pl', '[[pl.packageId]] = [[p.id]]')
-            ->innerJoin('content dc', '[[dc.elementId]] = [[pl.developerId]]')
-            ->innerJoin('users u', '[[u.id]] = [[pl.developerId]]')
+            ->innerJoin(Table::PLUGINS . ' pl', '[[pl.packageId]] = [[p.id]]')
+            ->innerJoin(CraftTable::CONTENT . ' dc', '[[dc.elementId]] = [[pl.developerId]]')
+            ->innerJoin(CraftTable::USERS . ' u', '[[u.id]] = [[pl.developerId]]')
             ->andWhere(['not', ['pv.time' => null]])
             ->andWhere(['not', ['pl.dateApproved' => null]])
             ->orderBy(['pv.time' => SORT_DESC])

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace craftnet\db;
+
+/**
+ * This class provides constants for defining Craftnet’s database table names.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ */
+abstract class Table
+{
+    public const CMSEDITIONS = '{{%craftnet_cmseditions}}';
+    public const CMSLICENSEHISTORY = '{{%craftnet_cmslicensehistory}}';
+    public const CMSLICENSES = '{{%craftnet_cmslicenses}}';
+    public const CMSLICENSES_LINEITEMS = '{{%craftnet_cmslicenses_lineitems}}';
+    public const CMSLICENSE_PLUGINS = '{{%craftnet_cmslicense_plugins}}';
+    public const CMSRENEWALS = '{{%craftnet_cmsrenewals}}';
+    public const CRAFT2PLUGINHITS = '{{%craftnet_craft2pluginhits}}';
+    public const DEVELOPERLEDGER = '{{%craftnet_developerledger}}';
+    public const DEVELOPERS = '{{%craftnet_developers}}';
+    public const EMAILCODES = '{{%craftnet_emailcodes}}';
+    public const INACTIVECMSLICENSES = '{{%craftnet_inactivecmslicenses}}';
+    public const INSTALLEDPLUGINS = '{{%craftnet_installedplugins}}';
+    public const PACKAGEDEPS = '{{%craftnet_packagedeps}}';
+    public const PACKAGES = '{{%craftnet_packages}}';
+    public const PACKAGEVERSIONS = '{{%craftnet_packageversions}}';
+    public const PARTNERCAPABILITIES = '{{%craftnet_partnercapabilities}}';
+    public const PARTNERHISTORY = '{{%craftnet_partnerhistory}}';
+    public const PARTNERLOCATIONS = '{{%craftnet_partnerlocations}}';
+    public const PARTNERPROJECTS = '{{%craftnet_partnerprojects}}';
+    public const PARTNERPROJECTSCREENSHOTS = '{{%craftnet_partnerprojectscreenshots}}';
+    public const PARTNERS = '{{%craftnet_partners}}';
+    public const PARTNERSIZES = '{{%craftnet_partnersizes}}';
+    public const PARTNERS_PARTNERCAPABILITIES = '{{%craftnet_partners_partnercapabilities}}';
+    public const PARTNERS_PARTNERSIZES = '{{%craftnet_partners_partnersizes}}';
+    public const PAYOUTS = '{{%craftnet_payouts}}';
+    public const PAYOUT_ERRORS = '{{%craftnet_payout_errors}}';
+    public const PAYOUT_ITEMS = '{{%craftnet_payout_items}}';
+    public const PLUGINCATEGORIES = '{{%craftnet_plugincategories}}';
+    public const PLUGINEDITIONS = '{{%craftnet_plugineditions}}';
+    public const PLUGINHISTORY = '{{%craftnet_pluginhistory}}';
+    public const PLUGINLICENSEHISTORY = '{{%craftnet_pluginlicensehistory}}';
+    public const PLUGINLICENSES = '{{%craftnet_pluginlicenses}}';
+    public const PLUGINLICENSES_LINEITEMS = '{{%craftnet_pluginlicenses_lineitems}}';
+    public const PLUGINRENEWALS = '{{%craftnet_pluginrenewals}}';
+    public const PLUGINS = '{{%craftnet_plugins}}';
+    public const PLUGINSCREENSHOTS = '{{%craftnet_pluginscreenshots}}';
+    public const PLUGINVERSIONCOMPAT = '{{%craftnet_pluginversioncompat}}';
+    public const PLUGINVERSIONORDER = '{{%craftnet_pluginversionorder}}';
+    public const VCSTOKENS = '{{%craftnet_vcstokens}}';
+}

--- a/src/developers/EmailVerifier.php
+++ b/src/developers/EmailVerifier.php
@@ -11,6 +11,7 @@ use craft\helpers\Db;
 use craft\helpers\Template;
 use craft\helpers\UrlHelper;
 use craftnet\behaviors\UserBehavior;
+use craftnet\db\Table;
 use craftnet\Module;
 use yii\base\BaseObject;
 use yii\base\InvalidArgumentException;
@@ -50,7 +51,7 @@ class EmailVerifier extends BaseObject
         $code = $securityService->generateRandomString(32);
 
         Craft::$app->getDb()->createCommand()
-            ->insert('craftnet_emailcodes', [
+            ->insert(Table::EMAILCODES, [
                 'userId' => $this->user->id,
                 'email' => $email,
                 'code' => $securityService->hashPassword($code),
@@ -96,14 +97,14 @@ class EmailVerifier extends BaseObject
         $interval = DateTimeHelper::secondsToInterval(Craft::$app->getConfig()->getGeneral()->verificationCodeDuration);
         $minCodeIssueDate = (new \DateTime('now', new \DateTimeZone('UTC')))->sub($interval);
         $db->createCommand()
-            ->delete('craftnet_emailcodes', ['<', 'dateIssued', Db::prepareDateForDb($minCodeIssueDate)])
+            ->delete(Table::EMAILCODES, ['<', 'dateIssued', Db::prepareDateForDb($minCodeIssueDate)])
             ->execute();
 
         // get all the codes for this user and email
         $condition = ['userId' => $this->user->id, 'email' => $email];
         $codes = (new Query())
             ->select(['code'])
-            ->from(['craftnet_emailcodes'])
+            ->from([Table::EMAILCODES])
             ->where($condition)
             ->column();
 
@@ -137,7 +138,7 @@ class EmailVerifier extends BaseObject
 
         // remove all verification codes for this user + email
         $db->createCommand()
-            ->delete('craftnet_emailcodes', $condition)
+            ->delete(Table::EMAILCODES, $condition)
             ->execute();
 
         return $num;

--- a/src/developers/FundsManager.php
+++ b/src/developers/FundsManager.php
@@ -10,6 +10,7 @@ use craft\helpers\App;
 use craft\helpers\ArrayHelper;
 use craft\helpers\Db;
 use craftnet\behaviors\UserBehavior;
+use craftnet\db\Table;
 use craftnet\errors\InaccessibleFundsException;
 use craftnet\errors\InsufficientFundsException;
 use craftnet\errors\MissingStripeAccountException;
@@ -62,7 +63,7 @@ class FundsManager extends BaseObject
     {
         return (new Query())
             ->select(['balance'])
-            ->from('craftnet_developers')
+            ->from(Table::DEVELOPERS)
             ->where(['id' => $this->developer->id])
             ->scalar(Craft::$app->getDb()->getPrimary());
     }
@@ -305,7 +306,7 @@ class FundsManager extends BaseObject
 
         if ($adjustment !== false) {
             $db->createCommand()
-                ->update('craftnet_developers',
+                ->update(Table::DEVELOPERS,
                     [
                         'balance' => new Expression("[[balance]] {$operator} :adjustment", [':adjustment' => $adjustment]),
                     ],
@@ -357,6 +358,6 @@ SQL;
             'dateCreated' => Db::prepareDateForDb(new \DateTime()),
         ])->execute();
 
-        return $db->getLastInsertID('craftnet_developerledger');
+        return $db->getLastInsertID(Table::DEVELOPERLEDGER);
     }
 }

--- a/src/partners/PartnerCapabilitiesQuery.php
+++ b/src/partners/PartnerCapabilitiesQuery.php
@@ -5,6 +5,7 @@ namespace craftnet\partners;
 
 use craft\db\Query;
 use craft\helpers\ArrayHelper;
+use craftnet\db\Table;
 
 /**
  * Class PartnerCapabilites
@@ -54,11 +55,11 @@ class PartnerCapabilitiesQuery extends Query
     {
         $this
             ->select(['pc.id id', 'pc.title title'])
-            ->from('craftnet_partnercapabilities pc');
+            ->from(Table::PARTNERCAPABILITIES . ' pc');
 
         if (isset($this->_partnerId)) {
             $this
-                ->innerJoin('craftnet_partners_partnercapabilities p_pc', '[[p_pc.partnercapabilitiesId]] = [[pc.id]]')
+                ->innerJoin(Table::PARTNERS_PARTNERCAPABILITIES . ' p_pc', '[[p_pc.partnercapabilitiesId]] = [[pc.id]]')
                 ->where(['p_pc.partnerId' => $this->_partnerId])
                 ->andWhere('[[pc.id]] = [[p_pc.partnercapabilitiesId]]');
         }

--- a/src/partners/PartnerHistory.php
+++ b/src/partners/PartnerHistory.php
@@ -5,12 +5,13 @@ namespace craftnet\partners;
 use Craft;
 use craft\base\Model;
 use craft\db\Query;
+use craftnet\db\Table;
 use JsonSerializable;
 use yii\helpers\ArrayHelper;
 
 class PartnerHistory extends Model implements JsonSerializable
 {
-    protected static $table = 'craftnet_partnerhistory';
+    protected static $table = Table::PARTNERHISTORY;
 
     public $id;
     public $partnerId;

--- a/src/partners/PartnerLocationsQuery.php
+++ b/src/partners/PartnerLocationsQuery.php
@@ -2,8 +2,8 @@
 
 namespace craftnet\partners;
 
-
 use craft\db\Query;
+use craftnet\db\Table;
 
 class PartnerLocationsQuery extends Query
 {
@@ -32,7 +32,7 @@ class PartnerLocationsQuery extends Query
     {
         $this
             ->select('*')
-            ->from('craftnet_partnerlocations l');
+            ->from(Table::PARTNERLOCATIONS . ' l');
 
         if (isset($this->_partnerId)) {
             $this->where(['l.partnerId' => $this->_partnerId]);

--- a/src/partners/PartnerProjectsQuery.php
+++ b/src/partners/PartnerProjectsQuery.php
@@ -2,8 +2,8 @@
 
 namespace craftnet\partners;
 
-
 use craft\db\Query;
+use craftnet\db\Table;
 
 class PartnerProjectsQuery extends Query
 {
@@ -32,7 +32,7 @@ class PartnerProjectsQuery extends Query
     {
         $this
             ->select('*')
-            ->from('craftnet_partnerprojects p')
+            ->from(Table::PARTNERPROJECTS . ' p')
             ->orderBy(['p.sortOrder' => SORT_ASC]);
 
         if (isset($this->_partnerId)) {

--- a/src/partners/PartnerQuery.php
+++ b/src/partners/PartnerQuery.php
@@ -4,6 +4,7 @@ namespace craftnet\partners;
 
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
+use craftnet\db\Table;
 use yii\db\Connection;
 
 /**
@@ -81,25 +82,25 @@ class PartnerQuery extends ElementQuery
         $this->joinElementTable('craftnet_partners');
 
         $this->query->select([
-            'craftnet_partners.ownerId',
-            'craftnet_partners.businessName',
-            'craftnet_partners.primaryContactName',
-            'craftnet_partners.primaryContactEmail',
-            'craftnet_partners.primaryContactPhone',
-            'craftnet_partners.fullBio',
-            'craftnet_partners.shortBio',
-            'craftnet_partners.agencySize',
-            'craftnet_partners.hasFullTimeDev',
-            'craftnet_partners.isCraftVerified',
-            'craftnet_partners.isCommerceVerified',
-            'craftnet_partners.isEnterpriseVerified',
-            'craftnet_partners.verificationStartDate',
-            'craftnet_partners.isRegisteredBusiness',
-            'craftnet_partners.region',
-            'craftnet_partners.expertise',
-            'craftnet_partners.websiteSlug',
-            'craftnet_partners.logoAssetId',
-            'craftnet_partners.website',
+            Table::PARTNERS . '.ownerId',
+            Table::PARTNERS . '.businessName',
+            Table::PARTNERS . '.primaryContactName',
+            Table::PARTNERS . '.primaryContactEmail',
+            Table::PARTNERS . '.primaryContactPhone',
+            Table::PARTNERS . '.fullBio',
+            Table::PARTNERS . '.shortBio',
+            Table::PARTNERS . '.agencySize',
+            Table::PARTNERS . '.hasFullTimeDev',
+            Table::PARTNERS . '.isCraftVerified',
+            Table::PARTNERS . '.isCommerceVerified',
+            Table::PARTNERS . '.isEnterpriseVerified',
+            Table::PARTNERS . '.verificationStartDate',
+            Table::PARTNERS . '.isRegisteredBusiness',
+            Table::PARTNERS . '.region',
+            Table::PARTNERS . '.expertise',
+            Table::PARTNERS . '.websiteSlug',
+            Table::PARTNERS . '.logoAssetId',
+            Table::PARTNERS . '.website',
         ]);
 
         $andWhereColumns = [
@@ -113,7 +114,9 @@ class PartnerQuery extends ElementQuery
 
         foreach ($andWhereColumns as $column) {
             if (isset($this->{$column})) {
-                $this->subQuery->andWhere(Db::parseParam('craftnet_partners.' . $column, $this->{$column}));
+                $this->subQuery->andWhere(
+                    Db::parseParam(Table::PARTNERS . '.' . $column, $this->{$column})
+                );
             }
         }
 

--- a/src/partners/PartnerService.php
+++ b/src/partners/PartnerService.php
@@ -13,6 +13,7 @@ use craft\helpers\ElementHelper;
 use craft\helpers\StringHelper;
 use craft\web\Request;
 use craft\web\UploadedFile;
+use craftnet\db\Table;
 use yii\base\Exception;
 use yii\helpers\ArrayHelper;
 
@@ -40,7 +41,7 @@ class PartnerService
 
         $screenshots = Asset::find()
             ->addSelect(['pps.projectId'])
-            ->innerJoin(['pps' => 'craftnet_partnerprojectscreenshots'], '[[pps.assetId]] = [[elements.id]]')
+            ->innerJoin(['pps' => Table::PARTNERPROJECTSCREENSHOTS], '[[pps.assetId]] = [[elements.id]]')
             ->andWhere(['pps.projectId' => ArrayHelper::getColumn($projects, 'id')])
             ->orderBy(['pps.sortOrder' => SORT_ASC])
             ->all();

--- a/src/partners/validators/PartnerSlugValidator.php
+++ b/src/partners/validators/PartnerSlugValidator.php
@@ -2,10 +2,10 @@
 
 namespace craftnet\partners\validators;
 
-
 use Craft;
 use craft\db\Query;
 use craft\validators\SlugValidator;
+use craftnet\db\Table;
 use craftnet\partners\Partner;
 
 class PartnerSlugValidator extends SlugValidator
@@ -22,7 +22,7 @@ class PartnerSlugValidator extends SlugValidator
         if (!$model->hasErrors()) {
             $query = (new Query())
                 ->select('COUNT(*)')
-                ->from('craftnet_partners')
+                ->from(Table::PARTNERS)
                 ->where(['websiteSlug' => $model->$attribute])
                 ->andWhere(['<>', 'id', $model->id]);
 

--- a/src/payouts/Payout.php
+++ b/src/payouts/Payout.php
@@ -3,6 +3,7 @@
 namespace craftnet\payouts;
 
 use craft\db\ActiveRecord;
+use craftnet\db\Table;
 use yii\db\ActiveQueryInterface;
 
 /**
@@ -19,7 +20,7 @@ class Payout extends ActiveRecord
      */
     public static function tableName()
     {
-        return 'craftnet_payouts';
+        return Table::PAYOUTS;
     }
 
     /**

--- a/src/payouts/PayoutItem.php
+++ b/src/payouts/PayoutItem.php
@@ -3,6 +3,7 @@
 namespace craftnet\payouts;
 
 use craft\db\ActiveRecord;
+use craftnet\db\Table;
 use yii\db\ActiveQueryInterface;
 
 /**
@@ -24,7 +25,7 @@ class PayoutItem extends ActiveRecord
      */
     public static function tableName()
     {
-        return 'craftnet_payout_items';
+        return Table::PAYOUT_ITEMS;
     }
 
     /**

--- a/src/payouts/PayoutManager.php
+++ b/src/payouts/PayoutManager.php
@@ -7,6 +7,7 @@ use craft\elements\User;
 use craft\helpers\App;
 use craft\helpers\Db;
 use craftnet\behaviors\UserBehavior;
+use craftnet\db\Table;
 use craftnet\developers\FundsManager;
 use craftnet\errors\InaccessibleFundsException;
 use PayPal\Api\Currency;
@@ -227,7 +228,7 @@ class PayoutManager extends BaseObject
         Craft::warning("Unsuccessful PayPal connection: {$e->getMessage()}");
         Craft::$app->getErrorHandler()->logException($e);
 
-        Db::insert('craftnet_payout_errors', [
+        Db::insert(Table::PAYOUT_ERRORS, [
             'payoutId' => $payoutId,
             'message' => $e->getMessage(),
             'data' => $e->getData(),

--- a/src/plugins/PluginEdition.php
+++ b/src/plugins/PluginEdition.php
@@ -12,6 +12,7 @@ use craft\helpers\ArrayHelper;
 use craft\helpers\Json;
 use craftnet\base\EditionInterface;
 use craftnet\base\RenewalInterface;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\helpers\OrderHelper;
 use craftnet\Module;
@@ -24,14 +25,8 @@ use yii\validators\CompareValidator;
  */
 class PluginEdition extends PluginPurchasable implements EditionInterface
 {
-    // Constants
-    // =========================================================================
-
     const SCENARIO_CP = 'cp';
     const SCENARIO_SITE = 'site';
-
-    // Static
-    // =========================================================================
 
     /**
      * @inheritdoc
@@ -69,7 +64,7 @@ class PluginEdition extends PluginPurchasable implements EditionInterface
         if ($handle === 'plugin') {
             $query = (new Query())
                 ->select(['id as source', 'pluginId as target'])
-                ->from(['craftnet_plugineditions'])
+                ->from([Table::PLUGINEDITIONS])
                 ->where(['id' => ArrayHelper::getColumn($sourceElements, 'id')]);
             return ['elementType' => Plugin::class, 'map' => $query->all()];
         }
@@ -113,9 +108,6 @@ class PluginEdition extends PluginPurchasable implements EditionInterface
         ];
     }
 
-    // Properties
-    // =========================================================================
-
     /**
      * @var string The edition name
      */
@@ -140,9 +132,6 @@ class PluginEdition extends PluginPurchasable implements EditionInterface
      * @var array|null Edition feature list
      */
     public $features;
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @return string
@@ -359,11 +348,11 @@ class PluginEdition extends PluginPurchasable implements EditionInterface
 
         if ($isNew) {
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_plugineditions', $data, false)
+                ->insert(Table::PLUGINEDITIONS, $data, false)
                 ->execute();
         } else {
             Craft::$app->getDb()->createCommand()
-                ->update('craftnet_plugineditions', $data, ['id' => $this->id], [], false)
+                ->update(Table::PLUGINEDITIONS, $data, ['id' => $this->id], [], false)
                 ->execute();
         }
 
@@ -551,7 +540,7 @@ class PluginEdition extends PluginPurchasable implements EditionInterface
 
             // relate the license to the line item
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_pluginlicenses_lineitems', [
+                ->insert(Table::PLUGINLICENSES_LINEITEMS, [
                     'licenseId' => $license->id,
                     'lineItemId' => $lineItem->id,
                 ], false)

--- a/src/plugins/PluginEditionQuery.php
+++ b/src/plugins/PluginEditionQuery.php
@@ -4,6 +4,7 @@ namespace craftnet\plugins;
 
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
+use craftnet\db\Table;
 use yii\db\Connection;
 
 /**
@@ -82,26 +83,26 @@ class PluginEditionQuery extends ElementQuery
         $this->joinElementTable('craftnet_plugineditions');
 
         $this->query->select([
-            'craftnet_plugineditions.pluginId',
-            'craftnet_plugineditions.name',
-            'craftnet_plugineditions.handle',
-            'craftnet_plugineditions.price',
-            'craftnet_plugineditions.renewalPrice',
-            'craftnet_plugineditions.features',
+            Table::PLUGINEDITIONS . '.pluginId',
+            Table::PLUGINEDITIONS . '.name',
+            Table::PLUGINEDITIONS . '.handle',
+            Table::PLUGINEDITIONS . '.price',
+            Table::PLUGINEDITIONS . '.renewalPrice',
+            Table::PLUGINEDITIONS . '.features',
         ]);
 
         if ($this->pluginId) {
-            $this->subQuery->andWhere(Db::parseParam('craftnet_plugineditions.pluginId', $this->pluginId));
+            $this->subQuery->andWhere(Db::parseParam(Table::PLUGINEDITIONS . '.pluginId', $this->pluginId));
         }
 
         if ($this->handle) {
-            $this->subQuery->andWhere(Db::parseParam('craftnet_plugineditions.handle', $this->handle));
+            $this->subQuery->andWhere(Db::parseParam(Table::PLUGINEDITIONS . '.handle', $this->handle));
         }
 
         if ($this->commercial === true) {
-            $this->subQuery->andWhere(['not', ['craftnet_plugineditions.price' => 0]]);
+            $this->subQuery->andWhere(['not', [Table::PLUGINEDITIONS . '.price' => 0]]);
         } else if ($this->commercial === false) {
-            $this->subQuery->andWhere(['craftnet_plugineditions.price' => 0]);
+            $this->subQuery->andWhere([Table::PLUGINEDITIONS . '.price' => 0]);
         }
 
         return parent::beforePrepare();

--- a/src/plugins/PluginHistory.php
+++ b/src/plugins/PluginHistory.php
@@ -4,14 +4,12 @@ namespace craftnet\plugins;
 
 use Craft;
 use craft\db\Query;
+use craftnet\db\Table;
 use yii\base\BaseObject;
 use yii\base\NotSupportedException;
 
 class PluginHistory extends BaseObject implements \IteratorAggregate, \ArrayAccess, \Countable
 {
-    // Properties
-    // =========================================================================
-
     /**
      * @var Plugin
      */
@@ -21,9 +19,6 @@ class PluginHistory extends BaseObject implements \IteratorAggregate, \ArrayAcce
      * @var array|null
      */
     private $_history;
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @param Plugin $plugin
@@ -46,7 +41,7 @@ class PluginHistory extends BaseObject implements \IteratorAggregate, \ArrayAcce
     public function push(string $note, string $devComments = null)
     {
         Craft::$app->getDb()->createCommand()
-            ->insert('craftnet_pluginhistory', [
+            ->insert(Table::PLUGINHISTORY, [
                 'pluginId' => $this->_plugin->id,
                 'note' => $note,
                 'devComments' => $devComments,
@@ -105,9 +100,6 @@ class PluginHistory extends BaseObject implements \IteratorAggregate, \ArrayAcce
         return count($this->_getHistory());
     }
 
-    // Private Methods
-    // =========================================================================
-
     /**
      * Returns the history data.
      *
@@ -125,7 +117,7 @@ class PluginHistory extends BaseObject implements \IteratorAggregate, \ArrayAcce
 
         return $this->_history = (new Query())
             ->select(['note', 'devComments', 'dateCreated'])
-            ->from(['craftnet_pluginhistory'])
+            ->from([Table::PLUGINHISTORY])
             ->where(['pluginId' => $this->_plugin->id])
             ->orderBy(['dateCreated' => SORT_DESC])
             ->all();

--- a/src/plugins/PluginRenewal.php
+++ b/src/plugins/PluginRenewal.php
@@ -7,6 +7,7 @@ use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
 use craft\elements\db\ElementQueryInterface;
 use craftnet\base\RenewalInterface;
+use craftnet\db\Table;
 use craftnet\errors\LicenseNotFoundException;
 use craftnet\helpers\OrderHelper;
 use craftnet\Module;
@@ -18,9 +19,6 @@ use yii\base\InvalidConfigException;
  */
 class PluginRenewal extends PluginPurchasable implements RenewalInterface
 {
-    // Static
-    // =========================================================================
-
     /**
      * @return string
      */
@@ -37,9 +35,6 @@ class PluginRenewal extends PluginPurchasable implements RenewalInterface
         return new PluginRenewalQuery(static::class);
     }
 
-    // Properties
-    // =========================================================================
-
     /**
      * @var int The plugin edition ID
      */
@@ -49,9 +44,6 @@ class PluginRenewal extends PluginPurchasable implements RenewalInterface
      * @var float The renewal price
      */
     public $price;
-
-    // Public Methods
-    // =========================================================================
 
     /**
      * @inheritdoc
@@ -87,11 +79,11 @@ class PluginRenewal extends PluginPurchasable implements RenewalInterface
 
         if ($isNew) {
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_pluginrenewals', $data, false)
+                ->insert(Table::PLUGINRENEWALS, $data, false)
                 ->execute();
         } else {
             Craft::$app->getDb()->createCommand()
-                ->update('craftnet_pluginrenewals', $data, ['id' => $this->id], [], false)
+                ->update(Table::PLUGINRENEWALS, $data, ['id' => $this->id], [], false)
                 ->execute();
         }
 
@@ -164,9 +156,6 @@ class PluginRenewal extends PluginPurchasable implements RenewalInterface
         parent::afterOrderComplete($order, $lineItem);
     }
 
-    // Private Methods
-    // =========================================================================
-
     /**
      * @param Order $order
      * @param LineItem $lineItem
@@ -198,7 +187,7 @@ class PluginRenewal extends PluginPurchasable implements RenewalInterface
 
             // relate the license to the line item
             Craft::$app->getDb()->createCommand()
-                ->insert('craftnet_pluginlicenses_lineitems', [
+                ->insert(Table::PLUGINLICENSES_LINEITEMS, [
                     'licenseId' => $license->id,
                     'lineItemId' => $lineItem->id,
                 ], false)

--- a/src/plugins/PluginRenewalQuery.php
+++ b/src/plugins/PluginRenewalQuery.php
@@ -4,6 +4,7 @@ namespace craftnet\plugins;
 
 use craft\elements\db\ElementQuery;
 use craft\helpers\Db;
+use craftnet\db\Table;
 use yii\db\Connection;
 
 /**
@@ -36,13 +37,13 @@ class PluginRenewalQuery extends ElementQuery
         $this->joinElementTable('craftnet_pluginrenewals');
 
         $this->query->select([
-            'craftnet_pluginrenewals.pluginId',
-            'craftnet_pluginrenewals.editionId',
-            'craftnet_pluginrenewals.price',
+            Table::PLUGINRENEWALS . '.pluginId',
+            Table::PLUGINRENEWALS . '.editionId',
+            Table::PLUGINRENEWALS . '.price',
         ]);
 
         if ($this->editionId) {
-            $this->subQuery->andWhere(Db::parseParam('craftnet_pluginrenewals.editionId', $this->editionId));
+            $this->subQuery->andWhere(Db::parseParam(Table::PLUGINRENEWALS . '.editionId', $this->editionId));
         }
 
         return parent::beforePrepare();

--- a/src/records/Plugin.php
+++ b/src/records/Plugin.php
@@ -10,6 +10,7 @@ namespace craftnet\records;
 use craft\db\ActiveRecord;
 use craft\records\Asset;
 use craft\records\User;
+use craftnet\db\Table;
 use yii\db\ActiveQueryInterface;
 
 /**
@@ -37,9 +38,6 @@ use yii\db\ActiveQueryInterface;
  */
 class Plugin extends ActiveRecord
 {
-    // Public Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      *
@@ -47,7 +45,7 @@ class Plugin extends ActiveRecord
      */
     public static function tableName(): string
     {
-        return 'craftnet_plugins';
+        return Table::PLUGINS;
     }
 
     /**

--- a/src/records/VcsToken.php
+++ b/src/records/VcsToken.php
@@ -9,6 +9,7 @@ namespace craftnet\records;
 
 use craft\db\ActiveRecord;
 use craft\records\User;
+use craftnet\db\Table;
 use yii\db\ActiveQueryInterface;
 
 /**
@@ -25,9 +26,6 @@ use yii\db\ActiveQueryInterface;
  */
 class VcsToken extends ActiveRecord
 {
-    // Public Methods
-    // =========================================================================
-
     /**
      * @inheritdoc
      *
@@ -35,7 +33,7 @@ class VcsToken extends ActiveRecord
      */
     public static function tableName(): string
     {
-        return 'craftnet_vcstokens';
+        return Table::VCSTOKENS;
     }
 
     /**

--- a/src/sales/SaleManager.php
+++ b/src/sales/SaleManager.php
@@ -5,15 +5,15 @@ namespace craftnet\sales;
 use craft\db\Query;
 use craft\elements\User;
 use craft\helpers\ArrayHelper;
+use craftnet\db\Table;
+use craft\db\Table as CraftTable;
+use craft\commerce\db\Table as CommerceTable;
 use craftnet\plugins\Plugin;
 use craftnet\plugins\PluginEdition;
 use yii\base\Component;
 
 class SaleManager extends Component
 {
-    // Public Methods
-    // =========================================================================
-
     /**
      * Get sales by plugin owner.
      *
@@ -83,7 +83,7 @@ class SaleManager extends Component
 
         $adjustments = (new Query())
             ->select(['lineItemId', 'name', 'amount'])
-            ->from(['commerce_orderadjustments'])
+            ->from([CommerceTable::ORDERADJUSTMENTS])
             ->where(['lineItemId' => $lineItemIds])
             ->all();
 
@@ -110,9 +110,6 @@ class SaleManager extends Component
         return $query->count();
     }
 
-    // Private Methods
-    // =========================================================================
-
     /**
      * Get sales query.
      *
@@ -137,13 +134,13 @@ class SaleManager extends Component
                 'elements.type AS purchasableType',
                 'licenses.editionId AS editionId',
             ])
-            ->from(['craftnet_pluginlicenses_lineitems licenses_items'])
-            ->innerJoin('commerce_lineitems lineitems', '[[lineitems.id]] = [[licenses_items.lineItemId]]')
-            ->innerJoin('commerce_orders orders', '[[orders.id]] = [[lineitems.orderId]]')
-            ->innerJoin('craftnet_pluginlicenses licenses', '[[licenses.id]] = [[licenses_items.licenseId]]')
-            ->innerJoin('craftnet_plugins plugins', '[[plugins.id]] = [[licenses.pluginId]]')
-            ->leftJoin('users', '[[users.id]] = [[licenses.ownerId]]')
-            ->leftJoin('elements', '[[elements.id]] = [[lineitems.purchasableId]]')
+            ->from([Table::PLUGINLICENSES_LINEITEMS . ' licenses_items'])
+            ->innerJoin(CommerceTable::LINEITEMS . ' lineitems', '[[lineitems.id]] = [[licenses_items.lineItemId]]')
+            ->innerJoin(CommerceTable::ORDERS . ' orders', '[[orders.id]] = [[lineitems.orderId]]')
+            ->innerJoin(Table::PLUGINLICENSES . ' licenses', '[[licenses.id]] = [[licenses_items.licenseId]]')
+            ->innerJoin(Table::PLUGINS . ' plugins', '[[plugins.id]] = [[licenses.pluginId]]')
+            ->leftJoin(CraftTable::USERS, '[[users.id]] = [[licenses.ownerId]]')
+            ->leftJoin(CraftTable::ELEMENTS, '[[elements.id]] = [[lineitems.purchasableId]]')
             ->where(['plugins.developerId' => $owner->id])
             ->orderBy(['lineitems.dateCreated' => SORT_DESC]);
 

--- a/src/services/Oauth.php
+++ b/src/services/Oauth.php
@@ -4,6 +4,7 @@ namespace craftnet\services;
 
 use Craft;
 use craft\db\Query;
+use craftnet\db\Table;
 use Github\Client as GithubClient;
 use Github\Exception\RuntimeException;
 use Github\ResultPager;
@@ -128,7 +129,7 @@ class Oauth extends Component
     {
         return (new Query())
             ->select(['accessToken'])
-            ->from(['craftnet_vcstokens'])
+            ->from([Table::VCSTOKENS])
             ->where(['userId' => $userId, 'provider' => $providerClass])
             ->scalar();
     }
@@ -152,7 +153,7 @@ class Oauth extends Component
                 'expiryDate',
                 'refreshToken',
             ])
-            ->from(['craftnet_vcstokens'])
+            ->from([Table::VCSTOKENS])
             ->where(['userId' => $userId, 'provider' => $providerClass])
             ->one();
     }
@@ -186,7 +187,7 @@ class Oauth extends Component
     public function deleteAccessToken($userId, $provider)
     {
         Craft::$app->getDb()->createCommand()
-            ->delete('craftnet_vcstokens', ['userId' => $userId, 'provider' => $provider])
+            ->delete(Table::VCSTOKENS, ['userId' => $userId, 'provider' => $provider])
             ->execute();
     }
 }

--- a/src/utilities/SalesReport.php
+++ b/src/utilities/SalesReport.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\base\Utility;
 use craft\commerce\elements\Order;
 use craft\db\Query;
+use craftnet\db\Table;
 
 class SalesReport extends Utility
 {
@@ -105,7 +106,7 @@ class SalesReport extends Utility
         foreach ($orders as $order) {
             $payments = (new Query())
                 ->select(['*'])
-                ->from(['craftnet_developerledger dl'])
+                ->from([Table::DEVELOPERLEDGER . ' dl'])
                 ->where(['ilike', 'note', $order['number']])
                 ->orderBy('dateCreated')
                 ->all();

--- a/src/utilities/UnavailablePlugins.php
+++ b/src/utilities/UnavailablePlugins.php
@@ -5,6 +5,7 @@ namespace craftnet\utilities;
 use Craft;
 use craft\base\Utility;
 use craft\db\Query;
+use craftnet\db\Table;
 
 class UnavailablePlugins extends Utility
 {
@@ -51,7 +52,7 @@ class UnavailablePlugins extends Utility
 
         $plugins = (new Query())
             ->select(['plugin', 'hits'])
-            ->from(['craftnet_craft2pluginhits'])
+            ->from([Table::CRAFT2PLUGINHITS])
             ->where(['available' => false])
             ->andWhere(['not', ['plugin' => $ignore]])
             ->orderBy(['hits' => SORT_DESC])


### PR DESCRIPTION
### Description

Following Craft and Commerce’s convention, this adds a Table class with constants for each Craftnet database table. It touches a frightening amount of code to swap those table references into queries instead of relying on hardcoded strings.

I didn’t purposefully update every reference to Craft and Commerce tables, but I made updates wherever I ran into them on this quest.

I ignored hardcoded table references in a few places:

1. `joinElementTable()` methods that require the un-prefixed table name.
2. Any `execute()` method arguments.
3. Raw SQL strings. Example:
    ```php
                        $prevLineItemSql = <<<SQL
    select li.options, o."datePaid"
    from commerce_lineitems li
    inner join commerce_orders o on li."orderId" = o.id
    inner join $joinTable l_li on l_li."lineItemId" = li.id
    where l_li."licenseId" = $licenseId
      and o."orderStatusId" = 3
      and li."orderId" < {$lineItem['orderId']}
    order by li."orderId" desc
    limit 1
    SQL;
    ```
4. Any `joinElementTable()` arguments.
5. Any `createCommand()` arguments.
6. Any `innerJoin()` and `where()` arguments. Example:
    ```
    ->innerJoin([Table::PACKAGEVERSIONS . ' v'], '[[v.packageId]] = [[craftnet_plugins.packageId]]')
    ```

Nothing breaks browsing around the control panel, but happy to make adjustments if I’ve been overly cautious or made any errors.