### PR TITLE
Add vigetx.com to dev domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -118,6 +118,7 @@ return [
     'untuckstage.com',
     'venveodev.com',
     'victhorious.com',
+    'vigetx.com',
     'vmgdev.com',
     'vrielingdev.nl',
     'wave-dev.com',


### PR DESCRIPTION
We use *.vigetx.com for staging & dev environments; it would be great if this could be added to your exclusion list. Thanks!
