### PR TITLE
add in vericreative dev domain

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -126,6 +126,7 @@ return [
     'umstesting.com',
     'untuckstage.com',
     'venveodev.com',
+    'vericreative.dev',
     'victhorious.com',
     'vigetx.com',
     'vmgdev.com',


### PR DESCRIPTION
### Description
Adding in the vericreative.dev domain to get rid of licensing warnings.


### Related issues

