### PR TITLE
Adding redeye.dev development domain for agency Red Eye Development

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -105,6 +105,7 @@ return [
     'psclients.net',
     'putyourlightson.dev',
     'rantsports.org',
+    'redeye.dev',
     'runcloud.site',
     'sandboxdsm.com',
     'servd.dev',


### PR DESCRIPTION
This adds Red Eye's dev domain, redeye.dev.
