### PR TITLE
Add Gitpod to development domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -47,6 +47,7 @@ return [
     'gbdev.co',
     'gcx.dev',
     'ghdev.xyz',
+    'gitpod.io',
     'gw-staging.com',
     'h6.vc',
     'happycogdev.com',


### PR DESCRIPTION
We are using [Gitpod](https://gitpod.io) for our development environments, and receive a license warning in the control panel.

Can this please be allowed as a whitelisted dev domain?