### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @brandonkelly @angrybrad @benjamindavid


### PR DESCRIPTION
### Description

Adds a GitHub [code owners](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) file. For maximum fun. Wasn’t sure if any parts of the code could be further assigned to specific people, so you may want to season to taste if that sounds fun.