### PR TITLE
Added atomix.dev domain to dev domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -5,6 +5,7 @@ return [
     'aanpqa.com',
     'ai-qa.com',
     'astuteo.dev',
+    'atomix.dev',
     'azure.com',
     'azurewebsites.us',
     'berts.space',


### PR DESCRIPTION
### Description

We're an agency (atomix.com.au) and we use Craft for a number of our clients, with all of our staging/pre-prod sites being on the atomix.dev domain.

It would be great to have this be on the list of dev domains so we don't have to have an ugly `dev.cms.client.atomix.dev` domain.