### PR TITLE
moving the dev subdomain words into their own file, adding 'stg' word

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -19,25 +19,7 @@ return [
                         'class' => craftnet\cms\CmsLicenseManager::class,
                         'devDomains' => require __DIR__ . '/dev-domains.php',
                         'publicDomainSuffixes' => require __DIR__ . '/public-domain-suffixes.php',
-                        'devSubdomainWords' => [
-                            'acc',
-                            'acceptance',
-                            'acceptatie',
-                            'craftdemo',
-                            'dev',
-                            'integration',
-                            'loc',
-                            'local',
-                            'preprod',
-                            'qa',
-                            'sandbox',
-                            'stage',
-                            'staging',
-                            'systest',
-                            'test',
-                            'testing',
-                            'uat',
-                        ]
+                        'devSubdomainWords' => require __DIR__ . '/dev-subdomain-keywords.php'
                     ],
                     'invoiceManager' => [
                         'class' => craftnet\invoices\InvoiceManager::class,

--- a/config/dev-subdomain-keywords.php
+++ b/config/dev-subdomain-keywords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'acc',
+    'acceptance',
+    'acceptatie',
+    'craftdemo',
+    'dev',
+    'integration',
+    'loc',
+    'local',
+    'preprod',
+    'qa',
+    'sandbox',
+    'stage',
+    'staging',
+    'systest',
+    'test',
+    'testing',
+    'uat',
+    'stg',
+];


### PR DESCRIPTION
### Description
This set of changes pulls the list of keywords used to detect a development subdomain out into its own separate file, in the same manner as the list of bare development domains and public domain suffixes. Additionally, this change adds the keyword 'stg' to the list of development subdomain keywords as it is used by some to represent a staging environment.


### Related issues
#272 
