### PR TITLE
Add imarc.io to dev domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -60,6 +60,7 @@ return [
     'hpc3.hpconnected.com',
     'hpsmartdev.com',
     'hyperlane.co',
+    'imarc.io',
     'infomedia-dev.com',
     'inspireserverc.com',
     'isted.dev',


### PR DESCRIPTION
Just a wildcard localhost domain similar to vcap.me, xip.io, lvh.me, or lacolhost.com, used for local development.

Thanks!