### PR TITLE
Add "stockwerk-dev" to dev-domains.php

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -125,6 +125,7 @@ return [
     'stagingbox.ca',
     'stagingbox.co.uk',
     'steadfa.st',
+    'stockwerk-dev.de',
     'stormdev.co.uk',
     'sunscreem.xyz',
     'tad.am',


### PR DESCRIPTION
We are an agency (stockwerk2.de) and use "stockwerk-dev.de" for staging sites for our clients.