### PR TITLE
Added ploi.link to dev domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -106,6 +106,7 @@ return [
     'our-staging-server.net',
     'pc-web.dev',
     'pennystamps.dev',
+    'ploi.link',
     'preflight.space',
     'preproduction.io',
     'preview.dev',
@@ -155,5 +156,4 @@ return [
     'wrkcpt.dev',
     'xip.io',
     'yourstruly.space',
-    'ploi.link',
 ];

--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -155,4 +155,5 @@ return [
     'wrkcpt.dev',
     'xip.io',
     'yourstruly.space',
+    'ploi.link',
 ];


### PR DESCRIPTION
Ploi.io uses *.ploi.link as temporary dev domains.