### PR TITLE
Adding mdev.onl for staging of client's work

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -82,6 +82,7 @@ return [
     'marbles.dev',
     'martinleveille.dev',
     'mcipreview.com',
+    'mdev.onl',
     'microserve-staging.ca',
     'miranj.dev',
     'mldev.net',


### PR DESCRIPTION
minimal design staging server uses the `client.mdev.onl` format for staging. Here's an [example of a craft powered site I'm building](http://wa.mdev.onl/products) right now.

### Description

I couldn't find the exact protocol to add an URL to your dev list, but looking at previous pull requests, it seems that creating a PR it is the preferred method? I apologies in advance if I misunderstood!

Thanks!

