### PR TITLE
Update dev-domains.php

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -37,6 +37,7 @@ return [
     'digitalliondev.com',
     'digitalpulse.dev',
     'dmdr.io',
+    'docksal.site',
     'dotmeta.com',
     'drivedev.net',
     'dw.gg',


### PR DESCRIPTION
add 'docksal.site' to list of known development domains

### Description
using .docksal.site (https://docksal.io/) domains for local dev gives license key warning. 
