### PR TITLE
Add `dative.dev` to dev domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -29,6 +29,7 @@ return [
     'craftdemos.io',
     'crudecode.com',
     'ddev.site',
+    'dative.dev',
     'deltablue.io',
     'designandbuildsandbox.com',
     'destinationcore.io',


### PR DESCRIPTION
I am sure you guys get a fair share of `dative.dev` licensing warnings. We use `*.dative.dev` domain exclusively for staging or pre-launch.

Let me know if this is the proper channel to do this, or there is another way. Thanks!