### PR TITLE
Add patmos.dev to development domains

### DIFF
--- a/config/dev-domains.php
+++ b/config/dev-domains.php
@@ -114,6 +114,7 @@ return [
     'ontwikkeling.site',
     'onyep.dev',
     'our-staging-server.net',
+    'patmos.dev',
     'pc-web.dev',
     'pennystamps.dev',
     'ploi.link',


### PR DESCRIPTION
My org is now using patmos.dev for our staging domain. Request to include here.
